### PR TITLE
Local player count adjustment

### DIFF
--- a/Server/src/org/crandor/game/content/skill/member/construction/HouseLocation.java
+++ b/Server/src/org/crandor/game/content/skill/member/construction/HouseLocation.java
@@ -12,7 +12,8 @@ import org.crandor.tools.StringUtils;
  */
 @SuppressWarnings("all")
 public enum HouseLocation {
-	
+
+	//Nowhere is used for players who do not have a house
 	NOWHERE(-1, null, 0, 0),
 	
 	RIMMINGTON(15478, Location.create(2953, 3224, 0), 5000, 1),
@@ -25,9 +26,10 @@ public enum HouseLocation {
 	
 	BRIMHAVEN(15481, Location.create(2757, 3178, 0), 15000, 40),
 	
-	YANILLE(15482, Location.create(2544, 3096, 0), 25000, 50),
-	
-	WHITERIDGE(43832, Location.create(3965, 3546, 0), 100_000, 60);
+	YANILLE(15482, Location.create(2544, 3096, 0), 25000, 50);
+
+	//custom island thing that previous source users had.
+	//WHITERIDGE(43832, Location.create(3965, 3546, 0), 100_000, 60);
 	
 	/**
 	 * The portal object id for this location.

--- a/Server/src/org/crandor/game/content/skill/member/construction/HouseManager.java
+++ b/Server/src/org/crandor/game/content/skill/member/construction/HouseManager.java
@@ -188,9 +188,9 @@ public final class HouseManager implements SavingModule {
 				return true;
 			}
 		});
-		if (player.getHouseManager() == this && location.equals(HouseLocation.WHITERIDGE)) {
+		/*if (player.getHouseManager() == this && location.equals(HouseLocation.WHITERIDGE)) {
 			//player.getAchievementDiaryManager().updateTask(player, DiaryType.WHITERIDGE, 2, 1, true);
-		}
+		}*/
 		if (location.equals(HouseLocation.YANILLE)) {
 			//player.getAchievementDiaryManager().updateTask(player, DiaryType.ARDOUGNE, 1, 5, true);
 		}

--- a/Server/src/plugin/command/PlayerCommandPlugin.java
+++ b/Server/src/plugin/command/PlayerCommandPlugin.java
@@ -102,22 +102,27 @@ public final class PlayerCommandPlugin extends CommandPlugin {
 				return true;
 
 			case "players":
-				int count = Repository.getPlayers().size();
-				int ironCount = 0;
-				int ultIronCount = 0;
+				int totalCount = Repository.getPlayers().size();
+				int ironmanCount = 0;
+				int ultIronmanCount = 0;
+				int botCount = 0;
 				for (Player p : Repository.getPlayers()) {
 					if (p.getIronmanManager().checkRestriction(IronmanMode.ULTIMATE)) {
-						ultIronCount++;
+						ultIronmanCount++;
 					}
 					if (p.getIronmanManager().checkRestriction(IronmanMode.STANDARD)) {
-						ironCount++;
+						ironmanCount++;
+					}
+					if (p.isArtificial()){
+						botCount++;
 					}
 				}
-				int regular = count - ironCount - ultIronCount;
-				if (count == 1) {
+				int regular = totalCount - ironmanCount - ultIronmanCount - botCount;
+				int playerCount = totalCount-botCount;
+				if (totalCount == 1) {
 					player.sendMessage("<col=3498db>There is 1 active player in this world.");
 				} else {
-					player.sendMessage("<col=3498db>There are " + count + " active players in this world: " + regular + " regular, " + ironCount + " iron, and " + ultIronCount + " ultimate iron.");
+					player.sendMessage("<col=3498db>There are " + playerCount + " active players in this world: " + regular + " regular, " + ironmanCount + " iron, and " + ultIronmanCount + " ultimate iron.");
 				}
 				return player.getRights() == Rights.REGULAR_PLAYER;
 

--- a/Server/src/plugin/skill/construction/EstateAgentDialogue.java
+++ b/Server/src/plugin/skill/construction/EstateAgentDialogue.java
@@ -26,6 +26,7 @@ public final class EstateAgentDialogue extends DialoguePlugin {
      * Represents the book item.
      */
     private static final Item BOOK = new Item(8463, 1);
+    private static HouseLocation moveLoc;
 
     /**
      * Constructs a new {@code EstateAgentDialogue} {@code Object}.
@@ -70,6 +71,8 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                     stage = 2;
                 }
                 break;
+
+            //Options for when a player has a house
             case 1:
                 switch (buttonId) {
                     case 1:
@@ -82,7 +85,7 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                         break;
                     case 3:
                         interpreter.sendDialogues(player, FacialExpression.NO_EXPRESSION, "Could I have a Construction guidebook?");
-                        stage = 60;
+                        stage = 50;
                         break;
                     case 4:
                         interpreter.sendDialogues(player, FacialExpression.NO_EXPRESSION, "Tell me about houses!");
@@ -94,6 +97,8 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                         break;
                 }
                 break;
+
+            //Option for when a player does not have a house
             case 2:
                 switch (buttonId) {
                     case 1:
@@ -106,17 +111,19 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                         break;
                 }
                 break;
+
+            //Real Estate Agent offering a house
             case 3:
                 npc("I can sell you a starting house in Rimmington for", "1000 coins. As you increase your construction skill you", "will be able to have your house moved to other areas", "and redecorated in other styles.");
-                stage = 4;
+                stage++;
                 break;
             case 4:
                 npc("Do you want to buy a starter house?");
-                stage = 5;
+                stage++;
                 break;
             case 5:
                 options("Yes please!", "No thanks.");
-                stage = 6;
+                stage++;
                 break;
             case 6:
                 switch (buttonId) {
@@ -130,6 +137,8 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                         break;
                 }
                 break;
+
+            //Estate Agent Dialogue after house purchase
             case 7:
                 if (player.getInventory().contains(995, 1000)) {
                     player.getInventory().remove(new Item(995, 1000));
@@ -141,79 +150,118 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                     stage = 150;
                 }
                 break;
-            case 8:
-                if (GameWorld.getSettings().isDevMode() && GameWorld.getSettings().isBeta()) {
-                    npc("This book will help you to start building your house.", "When you open the book you will receive some", "Construction resources.");
-                } else {
-                    npc("This book will help you to start building your house.");
-                }
-                player.getInventory().add(BOOK);
-                stage = 150;
-                break;
+
+            //Move House Dialogue
             case 10:
-                player("Can you move my house please?");
-//			HouseLocation.HOUSE_OPTIONS.open(player);
-                stage = 200;
+                npc("Certainly. Where would you like it moved to?");
+                stage++;
                 break;
+            case 11:
+                options("Rimmington (5,000)", "Taverley (5,000)", "Pollnivneach (7,500)", "Rellekka (10,000)", "More...");
+                stage++;
+                break;
+            case 12:
+                switch (buttonId) {
+                    case 1:
+                        player("To Rimmington please!");
+                        stage = 15;
+                        break;
+                    case 2:
+                        player("To Taverly please!");
+                        stage = 16;
+                        break;
+                    case 3:
+                        player("To Pollnivneach please!");
+                        stage = 17;
+                        break;
+                    case 4:
+                        player("To Rellekka please!");
+                        stage = 18;
+                        break;
+                    case 5:
+                        options("Brimhaven (15,000)", "Yanille (25,000)", "...Previous");
+                        stage = 13;
+                        break;
+                }
+                break;
+             case 13:
+                switch (buttonId) {
+                    case 1:
+                        player("To Brimhaven please!");
+                        stage = 19;
+                        break;
+                    case 2:
+                        player("To Yanille please!");
+                        stage = 20;
+                        break;
+                    case 3:
+                        options("Rimmington (5,000)", "Taverley (5,000)", "Pollnivneach (7,500)", "Rellekka (10,000)", "More...");
+                        stage = 12;
+                        break;
+                }
+                break;
+            case 15:
+                configureMove(HouseLocation.RIMMINGTON);
+                break;
+            case 16:
+                configureMove(HouseLocation.TAVERLY);
+                break;
+            case 17:
+                configureMove(HouseLocation.POLLNIVNEACH);
+                break;
+            case 18:
+                configureMove(HouseLocation.RELLEKKA);
+               break;
+            case 19:
+                configureMove(HouseLocation.BRIMHAVEN);
+                break;
+            case 20:
+                configureMove(HouseLocation.YANILLE);
+                break;
+
+
+            //Redecorate House
             case 30:
                 npc("Certainly. My magic can rebuild the house in a", "completely new style! What style would you like?");
-                stage = 31;
+                stage++;
                 break;
             case 31:
                 options("Basic wood (5,000)", "Basic stone (5,000)", "Whitewashed stone (7,500)", "Fremennik-style wood (10,000)", "More...");
-                stage = 32;
+                stage++;
                 break;
             case 32:
                 switch (buttonId) {
                     case 1:
                         player("Basic wood please!");
-                        stage = 33;
+                        stage = 35;
                         break;
                     case 2:
                         player("Basic stone please!");
-                        stage = 34;
+                        stage = 36;
                         break;
                     case 3:
                         player("Whitewashed stone please!");
-                        stage = 35;
+                        stage = 37;
                         break;
                     case 4:
                         player("Fremennik-style wood please!");
-                        stage = 36;
+                        stage = 38;
                         break;
                     case 5:
                         options("Tropical wood (15,000)", "Fancy stone (25,000)", "Previous...");
-                        stage = 39;
+                        stage = 33;
                         break;
                 }
                 break;
             case 33:
-                redecorate(HousingStyle.BASIC_WOOD);
-                break;
-            case 34:
-                redecorate(HousingStyle.BASIC_STONE);
-                break;
-            case 35:
-                redecorate(HousingStyle.WHITEWASHED_STONE);
-                break;
-            case 36:
-                redecorate(HousingStyle.FREMENNIK_STYLE_WOOD);
-                break;
-            case 37:
-                redecorate(HousingStyle.TROPICAL_WOOD);
-                break;
-            case 38:
-                redecorate(HousingStyle.FANCY_STONE);
-                break;
-            case 39:
                 switch (buttonId) {
                     case 1:
                         player("Tropical wood please!");
-                        stage = 37;
+                        stage = 39;
                         break;
                     case 2:
                         player("Fancy stone please!");
-                        stage = 38;
+                        stage = 40;
                         break;
                     case 3:
                         options("Basic wood (5,000)", "Basic stone (5,000)", "Whitewashed stone (7,500)", "Fremennik-style wood (10,000)", "More...");
@@ -221,31 +269,61 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                         break;
                 }
                 break;
+            case 35:
+                redecorate(HousingStyle.BASIC_WOOD);
+                break;
+            case 36:
+                redecorate(HousingStyle.BASIC_STONE);
+                break;
+            case 37:
+                redecorate(HousingStyle.WHITEWASHED_STONE);
+                break;
+            case 38:
+                redecorate(HousingStyle.FREMENNIK_STYLE_WOOD);
+                break;
+            case 39:
+                redecorate(HousingStyle.TROPICAL_WOOD);
+                break;
+            case 40:
+                redecorate(HousingStyle.FANCY_STONE);
+                break;
+
+            //Asking for a Construction Book
+            case 50:
+                if (!player.hasItem(BOOK)) {
+                    interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "Certainly.");
+                    player.getInventory().add(BOOK);
+                    stage = 150;
+                    break;
+                }else{
+                    interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "You've already got one!");
+                    stage = 150;
+                    break;
+                }
+
+            //More Information on houses
             case 60:
-                interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "Certainly.");
-                player.getInventory().add(BOOK);
-                stage = 150;
-                break;
-            case 90:
                 interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "It all came out of the wizards' experiments. They found", "a way to fold space, so that they could pack many", "acres of land into an area only a foot across.");
-                stage = 91;
+                stage++;
                 break;
-            case 91:
+            case 61:
                 interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "They created several folded-space regions across", "" + GameWorld.getName() + ". Each one contains hundreds of small plots", "where people can build houses.");
-                stage = 92;
+                stage++;
                 break;
-            case 92:
+            case 62:
                 interpreter.sendDialogues(player, FacialExpression.NO_EXPRESSION, "Ah, so that's how everyone can have a house without", "them cluttering up the world!");
-                stage = 93;
+                stage++;
                 break;
-            case 93:
+            case 63:
                 interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "Quite. The wizards didn't want to get bogged down", "in the business side of things so they ", "hired me to sell the houses.");
-                stage = 94;
+                stage++;
                 break;
-            case 94:
+            case 64:
                 interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "There are various other people across " + GameWorld.getName() + " who can", "help you furnish your house. You should start buying", "planks from the sawmill operator in Varrock.");
                 stage = 150;
                 break;
+
+            //Skillcape Dialogue for players without Level 99 Construction
             case 100:
                 interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "As you may know, skillcapes are only available to masters", "in a skill. I have spent my entire life building houses and", "now I spend my time selling them! As a sign of my abilites", "I wear this Skillcape of Construction. If you ever have");
                 stage = 101;
@@ -254,13 +332,15 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                 interpreter.sendDialogues(npc, FacialExpression.NO_EXPRESSION, "enough skill to build a demonic throne, come and talk to", "me and I'll sell you a skillcape like mine.");
                 stage = 150;
                 break;
+
+            //Skillcape Dialogue for players with Level 99 Construction
             case 102:
                 interpreter.sendDialogues(npc, FacialExpression.JOLLY, "I see you have recently achieved 99 construction.", "Would you like to buy a cape for 99,0000 gp?");
-                stage = 103;
+                stage++;
                 break;
             case 103:
                 interpreter.sendOptions("Select an Option", "Yes, I'll pay the 99k", "No thanks, maybe later.");
-                stage = 104;
+                stage++;
                 break;
             case 104:
                 switch (buttonId) {
@@ -271,51 +351,13 @@ public final class EstateAgentDialogue extends DialoguePlugin {
                         stage = 150;
                         break;
                     case 2:
+                        player("No thanks, maybe later.");
                         stage = 150;
                         break;
                 }
                 break;
-            case 200:
-                npc("Certainly. Where would you like it moved to?");
-                stage++;
-                break;
-            case 201:
-                options("Rimmington (5,000)", "Taverley (5,000)", "Pollnivneach (7,500)", "Rellekka (10,000)", "More...");
-                stage++;
-                break;
-            case 202:
-                switch (buttonId) {
-                    case 5:
-                        options("Brimhaven (15,000)", "Yanille (25,000)", "...Previous");
-                        stage++;
-                        break;
-                    default:
-                        configureMove(HouseLocation.values()[5 + buttonId]);
-                        break;
-                }
-                break;
-            case 203:
-                switch (buttonId) {
-                    case 3:
-                        options("Rimmington (5,000)", "Taverley (5,000)", "Pollnivneach (7,500)", "Rellekka (10,000)", "More...");
-                        stage++;
-                        break;
-                    default:
-                        configureMove(HouseLocation.values()[buttonId]);
-                        break;
-                }
-                break;
-            case 204:
-                HouseLocation moveLoc = player.getAttribute("con:moveLoc", HouseLocation.RIMMINGTON);
-                if (player.getHouseManager().getLocation() == moveLoc) {
-                    npc("Your house is already there!");
-                    break;
-                }
-                if (!moveLoc.hasLevel(player)) {
-                    npc("I'm afraid you don't have a high enough construction", "level to move there. You need to have level " + moveLoc.getLevelRequirement() + ".");
-                    break;
-                }
-                break;
+
+            //End
             case 150:
                 end();
                 break;
@@ -329,9 +371,25 @@ public final class EstateAgentDialogue extends DialoguePlugin {
      * @param location The house location.
      */
     private void configureMove(HouseLocation location) {
-        player.setAttribute("con:moveLoc", location);
-        player("To " + location.getName() + " please!");
-        stage = 64;
+        if (location == player.getHouseManager().getLocation()) {
+            npc("Your house is already there!");
+            stage = 11;
+            return;
+        }
+        if (location.getLevelRequirement() > player.getSkills().getStaticLevel(Skills.CONSTRUCTION)) {
+            npc("I'm afraid you don't have a high enough construction", "level to move there. You need to have level " + location.getLevelRequirement() + ".");
+            stage = 11;
+            return;
+        }
+        if (!player.getInventory().contains(995, location.getCost())) {
+            npc("Hmph. Come back when you have " + location.getCost() + " coins.");
+            stage = 150;
+            return;
+        }
+        player.getInventory().remove(new Item(995, location.getCost()));
+        player.getHouseManager().setLocation(location);
+        npc("Your house has been moved to " + location.getName() + ".");
+        stage = 150;
     }
 
     /**

--- a/Server/src/plugin/skill/construction/PortalOptionPlugin.java
+++ b/Server/src/plugin/skill/construction/PortalOptionPlugin.java
@@ -83,8 +83,22 @@ public final class PortalOptionPlugin extends OptionHandler {
 
 		@Override
 		public boolean open(Object... args) {
-			options("Go to your house", "Go to your house (building mode)", "Go to a friend's house", "Never mind");
-			stage = 1;
+			//If the player does not have a house
+			if (!player.getHouseManager().hasHouse()) {
+				player.getPacketDispatch().sendMessage("<col=FF0000>You don't have a house, talk to an estate agent to purchase a house.");
+			}
+			//If the Player has a house, but does not have their house moved to the portal they are interacting with
+			else if (player.getHouseManager().getLocation().getPortalId() != player.getAttribute("con:portal", -1)) {
+				player.getPacketDispatch().sendMessage("<col=FF0000>Your house is in " + player.getHouseManager().getLocation().getName() + ".");
+				player.sendMessage("<col=FF0000>Speak with an estate agent to change your house location.");
+			}
+
+			//If the above do not qualify, give the player options for housing
+			else {
+				options("Go to your house", "Go to your house (building mode)", "Go to a friend's house", "Never mind");
+				stage = 1;
+
+			}
 			return true;
 		}
 
@@ -96,15 +110,6 @@ public final class PortalOptionPlugin extends OptionHandler {
 				switch (buttonId) {
 				case 1:
 				case 2:
-					if (!player.getHouseManager().hasHouse()) {
-						player.getPacketDispatch().sendMessage("<col=FF0000>You don't have a house, talk to an estate agent to purchase a house.");
-						break;
-					}
-					if (player.getHouseManager().getLocation().getPortalId() != player.getAttribute("con:portal", -1)) {
-						player.getPacketDispatch().sendMessage("<col=FF0000>Your house is in " + player.getHouseManager().getLocation().name().toLowerCase() + ".");
-						player.sendMessage("<col=FF0000>Speak with an estate agent to change your house location.");
-						break;
-					}
 					player.getHouseManager().enter(player, buttonId == 2, true);
 					break;
 				case 3:


### PR DESCRIPTION
### Commands
___
- The `::players` command should no longer count the artificial players (for regular players).

### Construction Skill
___
- Added one or two missing dialogues for the Estate Agent
- Recoded a portion of the Estate Agent Diagloue so that it no longer locks up when purchasing different housing configurations (style and locations).
- The House Portals will now tell you if you do not own a house or that your house is in a different location **WITHOUT** opening up the options menu for them.
- Added some comments for the Estate Agent, Portal Option, House Location, and House Manager files.
- Some other possible small tweaks (I wrote this stuff a couple of days ago)...