### PR TITLE
Add ability to set exp rate to 10x by talking to Hans

### DIFF
--- a/Server/src/org/crandor/game/content/skill/Skills.java
+++ b/Server/src/org/crandor/game/content/skill/Skills.java
@@ -2,14 +2,11 @@ package org.crandor.game.content.skill;
 
 import org.crandor.game.content.global.SkillcapePerks;
 import org.crandor.game.content.global.tutorial.TutorialSession;
-import org.crandor.game.content.holiday.HolidayEvent;
 import org.crandor.game.node.entity.Entity;
 import org.crandor.game.node.entity.combat.ImpactHandler;
 import org.crandor.game.node.entity.npc.NPC;
 import org.crandor.game.node.entity.player.Player;
-import org.crandor.game.node.entity.player.link.IronmanMode;
 import org.crandor.game.node.entity.player.link.request.assist.AssistSession;
-import org.crandor.game.system.SystemManager;
 import org.crandor.game.world.repository.Repository;
 import org.crandor.game.world.update.flag.player.AppearanceFlag;
 import org.crandor.net.packet.PacketRepository;
@@ -27,7 +24,7 @@ public final class Skills {
 	/**
 	 * Represents the constant modifier of experience.
 	 */
-	public static final double EXPERIENCE_MULTIPLIER = 20;
+	public double experienceMutiplier = 5.0;
 
 	/**
 	 * The maximum experience multiplier.
@@ -261,7 +258,7 @@ public final class Skills {
 	private double getExperienceMod(int slot, double experience, boolean playerMod, boolean multiplyer) {
 		//Keywords for people ctrl + Fing the project
 		//xprate xp rate xp multiplier skilling rate
-		return 5.0;
+		return experienceMutiplier;
 		/*if (!(entity instanceof Player)) {
 			return 1.0;
 		}
@@ -359,6 +356,10 @@ public void parse(ByteBuffer buffer) {
 	experienceGained = buffer.getInt();
 }
 
+public void parseExpRate(ByteBuffer buffer) {
+	experienceMutiplier = buffer.getDouble();
+}
+
 /**
  * Saves the skill data on the buffer.
  * @param buffer The byte buffer.
@@ -376,6 +377,10 @@ public void save(ByteBuffer buffer) {
 		buffer.put((byte) staticLevels[i]);
 	}
 	buffer.putInt(experienceGained);
+}
+
+public void saveExpRate(ByteBuffer buffer) {
+	buffer.putDouble(experienceMutiplier);
 }
 
 /**

--- a/Server/src/org/crandor/game/node/entity/player/info/login/PlayerParser.java
+++ b/Server/src/org/crandor/game/node/entity/player/info/login/PlayerParser.java
@@ -146,6 +146,9 @@ public final class PlayerParser {
 					player.getSkills().setCombatMilestone(buffer.get() & 0xFF);
 					player.getSkills().setSkillMilestone(buffer.get() & 0xFF);
 					break;
+				case 46:
+					player.getSkills().parseExpRate(buffer);
+					break;
 				default:
 					System.err.println("[Player parsing] Unhandled opcode: " + opcode + " for " + player.getName() + " - [log=" + Arrays.toString(opcodeLog) + "].");
 					break;
@@ -297,7 +300,9 @@ public final class PlayerParser {
 		if (player.getSkills().getCombatMilestone() > 0 || player.getSkills().getSkillMilestone() > 0) {
 			buffer.put((byte) 45).put((byte) player.getSkills().getCombatMilestone()).put((byte) player.getSkills().getSkillMilestone());
 		}
-		
+
+		player.getSkills().saveExpRate(buffer.put((byte) 46));
+
 		buffer.put((byte) 0); // EOF opcode
 		buffer.flip();
 		File file = new File(directory + "players/" + player.getName() + ".save");

--- a/Server/src/plugin/activity/pestcontrol/reward/PCRewardInterface.java
+++ b/Server/src/plugin/activity/pestcontrol/reward/PCRewardInterface.java
@@ -199,7 +199,7 @@ public final class PCRewardInterface extends ComponentPlugin {
 		} else if (skillId == Skills.MAGIC || skillId == Skills.RANGE) {
 			divideBy = 29;//19.1-31 ideal range
 		}
-		return (int) ((level * level) / divideBy) * (Skills.EXPERIENCE_MULTIPLIER / 2);
+		return (int) ((level * level) / divideBy) * (player.getSkills().experienceMutiplier / 2);
 	}
 
 	/**
@@ -284,7 +284,7 @@ public final class PCRewardInterface extends ComponentPlugin {
 			if (reward.isSkillReward()) {
 				final double experience = ((int) calculateExperience(player, reward.getSkill()) * points);
 				player.getSkills().addExperience(reward.getSkill(), experience);
-				message = "The Void Knight has granted you " + (int) (experience * Skills.EXPERIENCE_MULTIPLIER) + " " + reward.getName() + ".";
+				message = "The Void Knight has granted you " + (int) (experience * player.getSkills().experienceMutiplier) + " " + reward.getName() + ".";
 			} else {
 				if (!reward.checkItemRequirement(player, option)) {
 					return;

--- a/Server/src/plugin/dialogue/HansDialoguePlugin.java
+++ b/Server/src/plugin/dialogue/HansDialoguePlugin.java
@@ -119,14 +119,14 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 				end();
 				break;
 			case 150:
-				interpreter.sendOptions("Select an Option", "Set my exp rate to 15x", "Nevermind");
+				interpreter.sendOptions("Select an Option", "Set my exp rate to 10x", "Nevermind");
 				stage++;
 				break;
 			case 151:
 				switch (buttonId) {
 					case 1:
 						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "Tada! Your experience rate is now 15x.", "Happy Scaping!");
-						player.getSkills().experienceMutiplier = 15.0;
+						player.getSkills().experienceMutiplier = 10.0;
 						stage = 50;
 						break;
 					case 2:

--- a/Server/src/plugin/dialogue/HansDialoguePlugin.java
+++ b/Server/src/plugin/dialogue/HansDialoguePlugin.java
@@ -51,7 +51,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 
 		switch (stage) {
 			case 0:
-				interpreter.sendOptions("Select an Option", "I'm looking for whoever is in charge of this place.", "I have come to kill everyone in this castle!", "I don't know. I'm lost. Where am I?", "Have you been here as long as me?");
+				interpreter.sendOptions("Select an Option", "I'm looking for whoever is in charge of this place.", "I have come to kill everyone in this castle!", "I don't know. I'm lost. Where am I?", "Have you been here as long as me?", "I'd like to learn faster!");
 				stage++;
 				break;
 			case 1:
@@ -74,6 +74,15 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 					case 4:
 						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "I've been patrolling this castle for years!");
 						stage = 40;
+						break;
+					case 5:
+						if (player.getSkills().experienceMutiplier == 15.0) {
+							interpreter.sendDialogues(npc, FacialExpression.OSRS_NORMAL, "Sorry, but you're already at the fastest experience", "rate. It's only a one way operation, and", "you can't learn faster yet I'm afraid!");
+							stage = 50;
+						} else {
+							interpreter.sendDialogues(npc, FacialExpression.HAPPY, "That's great! I can help you with that, but", "I must warn you it's only a one-way thing. There's no", "going back!");
+							stage = 150;
+						}
 						break;
 				}
 
@@ -108,6 +117,23 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 			//Closing Chat
 			case 50:
 				end();
+				break;
+			case 150:
+				interpreter.sendOptions("Select an Option", "Set my exp rate to 15x", "Nevermind");
+				stage++;
+				break;
+			case 151:
+				switch (buttonId) {
+					case 1:
+						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "Tada! Your experience rate is now 15x.", "Happy Scaping!");
+						player.getSkills().experienceMutiplier = 15.0;
+						stage = 50;
+						break;
+					case 2:
+					    end();
+						break;
+				}
+
 				break;
 		}
 

--- a/Server/src/plugin/interaction/inter/ExperienceLampInterface.java
+++ b/Server/src/plugin/interaction/inter/ExperienceLampInterface.java
@@ -80,13 +80,13 @@ public final class ExperienceLampInterface extends ComponentPlugin {
 			double experience = skillLevel * modifier;
 			if (type != null && type != Lamps.GENIE_LAMP) {
 				player.getDialogueInterpreter().open(70099, new Object[] { "The lamp gives you " + (int) type.getExp() + " " + Skills.SKILL_NAME[skillType.skill] + " experience." });
-				experience =  type.getExp() / Skills.EXPERIENCE_MULTIPLIER;
+				experience =  type.getExp() / player.getSkills().experienceMutiplier;
 				int skill = skillType.skill;
 				if (skill == Skills.ATTACK || skill == Skills.DEFENCE || skill == Skills.HITPOINTS || skill == Skills.STRENGTH || skill == Skills.STRENGTH || skill == Skills.MAGIC || skill == Skills.RANGE) {
 					experience /= 2;	
 				}
 			} else {
-				player.getDialogueInterpreter().open(70099, new Object[] { "The lamp gives you " + (experience * (Skills.EXPERIENCE_MULTIPLIER)) + " " + Skills.SKILL_NAME[skillType.skill] + " experience." });
+				player.getDialogueInterpreter().open(70099, new Object[] { "The lamp gives you " + (experience * (player.getSkills().experienceMutiplier)) + " " + Skills.SKILL_NAME[skillType.skill] + " experience." });
 			}
 			player.getSkills().addExperience(skillType.skill, experience, false);
 		}


### PR DESCRIPTION
Turns EXPERIENCE_MULTIPLIER into a non-final, non-static variable

By default it's 5, tested with pre-existing and new accs

Talk to Han's to make it 15, this is a one-way operation (no way to get 5x back)
 