### PR TITLE
[Needs Further Testing] Hardcore Iron Man Mode, Changing or De-Ironing at Hans, Some other Dialogue adjustments

### DIFF
--- a/Server/src/org/crandor/game/content/skill/Skills.java
+++ b/Server/src/org/crandor/game/content/skill/Skills.java
@@ -301,596 +301,608 @@ public final class Skills {
 		return mod;*/
 	}
 
-/**
- * Adds experience to the skills.
- */
-public void addExperience(final int slot, double experience) {
-	addExperience(slot, experience, false);
-}
+	/**
+	 * Adds experience to the skills.
+	 */
+	public void addExperience(final int slot, double experience) {
+		addExperience(slot, experience, false);
+	}
 
-/**
- * Gets the highest combat skill id.
- * @return The id of the highest combat skill.
- */
-public int getHighestCombatSkill() {
-	int id = 0;
-	int last = 0;
-	for (int i = 0; i < 5; i++) {
-		if (staticLevels[i] > last) {
-			last = staticLevels[i];
-			id = i;
+	/**
+	 * Gets the highest combat skill id.
+	 * @return The id of the highest combat skill.
+	 */
+	public int getHighestCombatSkill() {
+		int id = 0;
+		int last = 0;
+		for (int i = 0; i < 5; i++) {
+			if (staticLevels[i] > last) {
+				last = staticLevels[i];
+				id = i;
+			}
 		}
+		return id;
 	}
-	return id;
-}
 
-/**
- * Returns the dynamic levels to the static levels
- */
-public void restore() {
-	for (int i = 0; i < 24; i++) {
-		int staticLevel = getStaticLevel(i);
-		setLevel(i, staticLevel);
-	}
-	if (entity instanceof Player) {
-		entity.asPlayer().getAudioManager().send(2674);
-	}
-	rechargePrayerPoints();
-}
-
-/**
- * Parses the skill data from the buffer.
- * @param buffer The byte buffer.
- */
-public void parse(ByteBuffer buffer) {
-	for (int i = 0; i < 24; i++) {
-		experience[i] = ((double) buffer.getInt() / 10D);
-		dynamicLevels[i] = buffer.get() & 0xFF;
-		if (i == HITPOINTS) {
-			lifepoints = dynamicLevels[i];
-		} else if (i == PRAYER) {
-			prayerPoints = dynamicLevels[i];
+	/**
+	 * Returns the dynamic levels to the static levels
+	 */
+	public void restore() {
+		for (int i = 0; i < 24; i++) {
+			int staticLevel = getStaticLevel(i);
+			setLevel(i, staticLevel);
 		}
-		staticLevels[i] = buffer.get() & 0xFF;
-	}
-	experienceGained = buffer.getInt();
-}
-
-public void parseExpRate(ByteBuffer buffer) {
-	experienceMutiplier = buffer.getDouble();
-}
-
-/**
- * Saves the skill data on the buffer.
- * @param buffer The byte buffer.
- */
-public void save(ByteBuffer buffer) {
-	for (int i = 0; i < 24; i++) {
-		buffer.putInt((int) (experience[i] * 10));
-		if (i == HITPOINTS) {
-			buffer.put((byte) lifepoints);
-		} else if (i == PRAYER) {
-			buffer.put((byte) Math.ceil(prayerPoints));
-		} else {
-			buffer.put((byte) dynamicLevels[i]);
-		}
-		buffer.put((byte) staticLevels[i]);
-	}
-	buffer.putInt(experienceGained);
-}
-
-public void saveExpRate(ByteBuffer buffer) {
-	buffer.putDouble(experienceMutiplier);
-}
-
-/**
- * Refreshes all the skill levels.
- */
-public void refresh() {
-	if (!(entity instanceof Player)) {
-		return;
-	}
-	Player player = (Player) entity;
-	for (int i = 0; i < 24; i++) {
-		PacketRepository.send(SkillLevel.class, new SkillContext(player, i));
-	}
-	LevelUp.sendFlashingIcons(player, -1);
-}
-
-/**
- * Gets the static level.
- * @param slot The skill's slot.
- * @return The level.
- */
-public int getStaticLevelByExperience(int slot) {
-	double exp = experience[slot];
-
-	int points = 0;
-	int output = 0;
-	for (byte lvl = 1; lvl < 100; lvl++) {
-		points += Math.floor(lvl + 300.0 * Math.pow(2.0, lvl / 7.0));
-		output = (int) Math.floor(points / 4);
-		if ((output - 1) >= exp) {
-			return lvl;
-		}
-	}
-	return 99;
-}
-
-/**
- * Gets the experience for a certain level.
- * @param level The level.
- * @return The experience needed.
- */
-public int getExperienceByLevel(int level) {
-	int points = 0;
-	int output = 0;
-	for (int lvl = 1; lvl <= level; lvl++) {
-		points += Math.floor(lvl + 300.0 * Math.pow(2.0, lvl / 7.0));
-		if (lvl >= level) {
-			return output;
-		}
-		output = (int) Math.floor(points / 4);
-	}
-	return 0;
-}
-
-/**
- * Updates the combat level.
- * @return {@code True} if the combat level changed.
- */
-@SuppressWarnings("deprecation")
-public boolean updateCombatLevel() {
-	boolean update = false;
-	int level = calculateCombatLevel();
-	update = level != entity.getProperties().getCombatLevel();
-	if (entity instanceof Player) {
-		Player player = (Player) entity;
-		int summon = staticLevels[SUMMONING] / 8;
-		if (summon != player.getFamiliarManager().getSummoningCombatLevel()) {
-			player.getFamiliarManager().setSummoningCombatLevel(summon);
-			update = true;
-		}
-	}
-	entity.getProperties().setCombatLevel(level);
-	return update;
-}
-
-/**
- * Gets the combat level (ignoring summoning).
- * @return The combat level.
- */
-private int calculateCombatLevel() {
-	if (entity instanceof NPC) {
-		return ((NPC) entity).getDefinition().getCombatLevel();
-	}
-	int combatLevel = 0;
-	int melee = staticLevels[ATTACK] + staticLevels[STRENGTH];
-	int range = (int) (1.5 * staticLevels[RANGE]);
-	int mage = (int) (1.5 * staticLevels[MAGIC]);
-	if (melee > range && melee > mage) {
-		combatLevel = melee;
-	} else if (range > melee && range > mage) {
-		combatLevel = range;
-	} else {
-		combatLevel = mage;
-	}
-	combatLevel = staticLevels[DEFENCE] + staticLevels[HITPOINTS] + (staticLevels[PRAYER] / 2) + (int) (1.3 * combatLevel);
-	return combatLevel / 4;
-}
-
-/**
- * @return the player
- */
-public Entity getEntity() {
-	return entity;
-}
-
-/**
- * Gets the experience.
- * @param slot The slot.
- * @return The experience.
- */
-public double getExperience(int slot) {
-	return experience[slot];
-}
-
-/**
- * Gets the static skill level.
- * @param slot The slot.
- * @return The static level.
- */
-public int getStaticLevel(int slot) {
-	return staticLevels[slot];
-}
-
-/**
- * Sets the experience gained.
- * @param experienceGained The experience gained.
- */
-public void setExperienceGained(int experienceGained) {
-	this.experienceGained = experienceGained;
-}
-
-/**
- * Gets the experience gained.
- * @return The experience gained.
- */
-public int getExperienceGained() {
-	return experienceGained;
-}
-
-/**
- * Sets a dynamic level.
- * @param slot The skill id.
- * @param level The level.
- */
-public void setLevel(int slot, int level) {
-	if (slot == HITPOINTS) {
-		lifepoints = level;
-	} else if (slot == PRAYER) {
-		prayerPoints = level;
-	}
-	dynamicLevels[slot] = level;
-	if (restoration[slot] != null) {
-		restoration[slot].restart();
-	}
-	if (entity instanceof Player) {
-		PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, slot));
-	}
-}
-
-/**
- * Gets a dynamic level.
- * @param slot The skill id.
- * @return The dynamic level.
- */
-public int getLevel(int slot, boolean discardAssist) {
-	if (!discardAssist) {
 		if (entity instanceof Player) {
-			final Player p = (Player) entity;
-			final AssistSession assist = p.getExtension(AssistSession.class);
-			if (assist != null && assist.getPlayer() != p) {
-				Player assister = assist.getPlayer();
-				int index = assist.getSkillIndex(slot);
-				if (index != -1 && !assist.isRestricted()) {
-					// System.out.println(index + ", " +
-					// assist.getSkills()[index] + ", " + SKILL_NAME[slot]);
-					if (assist.getSkills()[index]) {
-						int assistLevel = assister.getSkills().getLevel(slot);
-						int playerLevel = dynamicLevels[slot];
-						if (assistLevel > playerLevel) {
-							return assistLevel;
+			entity.asPlayer().getAudioManager().send(2674);
+		}
+		rechargePrayerPoints();
+	}
+
+	/**
+	 * Parses the skill data from the buffer.
+	 * @param buffer The byte buffer.
+	 */
+	public void parse(ByteBuffer buffer) {
+		for (int i = 0; i < 24; i++) {
+			experience[i] = ((double) buffer.getInt() / 10D);
+			dynamicLevels[i] = buffer.get() & 0xFF;
+			if (i == HITPOINTS) {
+				lifepoints = dynamicLevels[i];
+			} else if (i == PRAYER) {
+				prayerPoints = dynamicLevels[i];
+			}
+			staticLevels[i] = buffer.get() & 0xFF;
+		}
+		experienceGained = buffer.getInt();
+	}
+
+	public void parseExpRate(ByteBuffer buffer) {
+		experienceMutiplier = buffer.getDouble();
+	}
+
+	/**
+	 * Saves the skill data on the buffer.
+	 * @param buffer The byte buffer.
+	 */
+	public void save(ByteBuffer buffer) {
+		for (int i = 0; i < 24; i++) {
+			buffer.putInt((int) (experience[i] * 10));
+			if (i == HITPOINTS) {
+				buffer.put((byte) lifepoints);
+			} else if (i == PRAYER) {
+				buffer.put((byte) Math.ceil(prayerPoints));
+			} else {
+				buffer.put((byte) dynamicLevels[i]);
+			}
+			buffer.put((byte) staticLevels[i]);
+		}
+		buffer.putInt(experienceGained);
+	}
+
+	public void saveExpRate(ByteBuffer buffer) {
+		buffer.putDouble(experienceMutiplier);
+	}
+
+	/**
+	 * Refreshes all the skill levels.
+	 */
+	public void refresh() {
+		if (!(entity instanceof Player)) {
+			return;
+		}
+		Player player = (Player) entity;
+		for (int i = 0; i < 24; i++) {
+			PacketRepository.send(SkillLevel.class, new SkillContext(player, i));
+		}
+		LevelUp.sendFlashingIcons(player, -1);
+	}
+
+	/**
+	 * Gets the static level.
+	 * @param slot The skill's slot.
+	 * @return The level.
+	 */
+	public int getStaticLevelByExperience(int slot) {
+		double exp = experience[slot];
+
+		int points = 0;
+		int output = 0;
+		for (byte lvl = 1; lvl < 100; lvl++) {
+			points += Math.floor(lvl + 300.0 * Math.pow(2.0, lvl / 7.0));
+			output = (int) Math.floor(points / 4);
+			if ((output - 1) >= exp) {
+				return lvl;
+			}
+		}
+		return 99;
+	}
+
+	/**
+	 * Gets the experience for a certain level.
+	 * @param level The level.
+	 * @return The experience needed.
+	 */
+	public int getExperienceByLevel(int level) {
+		int points = 0;
+		int output = 0;
+		for (int lvl = 1; lvl <= level; lvl++) {
+			points += Math.floor(lvl + 300.0 * Math.pow(2.0, lvl / 7.0));
+			if (lvl >= level) {
+				return output;
+			}
+			output = (int) Math.floor(points / 4);
+		}
+		return 0;
+	}
+
+	/**
+	 * Updates the combat level.
+	 * @return {@code True} if the combat level changed.
+	 */
+	@SuppressWarnings("deprecation")
+	public boolean updateCombatLevel() {
+		boolean update = false;
+		int level = calculateCombatLevel();
+		update = level != entity.getProperties().getCombatLevel();
+		if (entity instanceof Player) {
+			Player player = (Player) entity;
+			int summon = staticLevels[SUMMONING] / 8;
+			if (summon != player.getFamiliarManager().getSummoningCombatLevel()) {
+				player.getFamiliarManager().setSummoningCombatLevel(summon);
+				update = true;
+			}
+		}
+		entity.getProperties().setCombatLevel(level);
+		return update;
+	}
+
+	/**
+	 * Gets the combat level (ignoring summoning).
+	 * @return The combat level.
+	 */
+	private int calculateCombatLevel() {
+		if (entity instanceof NPC) {
+			return ((NPC) entity).getDefinition().getCombatLevel();
+		}
+		int combatLevel = 0;
+		int melee = staticLevels[ATTACK] + staticLevels[STRENGTH];
+		int range = (int) (1.5 * staticLevels[RANGE]);
+		int mage = (int) (1.5 * staticLevels[MAGIC]);
+		if (melee > range && melee > mage) {
+			combatLevel = melee;
+		} else if (range > melee && range > mage) {
+			combatLevel = range;
+		} else {
+			combatLevel = mage;
+		}
+		combatLevel = staticLevels[DEFENCE] + staticLevels[HITPOINTS] + (staticLevels[PRAYER] / 2) + (int) (1.3 * combatLevel);
+		return combatLevel / 4;
+	}
+
+	/**
+	 * @return the player
+	 */
+	public Entity getEntity() {
+		return entity;
+	}
+
+	/**
+	 * Gets the experience.
+	 * @param slot The slot.
+	 * @return The experience.
+	 */
+	public double getExperience(int slot) {
+		return experience[slot];
+	}
+
+	/**
+	 * Gets the static skill level.
+	 * @param slot The slot.
+	 * @return The static level.
+	 */
+	public int getStaticLevel(int slot) {
+		return staticLevels[slot];
+	}
+
+	/**
+	 * Sets the experience gained.
+	 * @param experienceGained The experience gained.
+	 */
+	public void setExperienceGained(int experienceGained) {
+		this.experienceGained = experienceGained;
+	}
+
+	/**
+	 * Gets the experience gained.
+	 * @return The experience gained.
+	 */
+	public int getExperienceGained() {
+		return experienceGained;
+	}
+
+	/**
+	 * Sets a dynamic level.
+	 * @param slot The skill id.
+	 * @param level The level.
+	 */
+	public void setLevel(int slot, int level) {
+		if (slot == HITPOINTS) {
+			lifepoints = level;
+		} else if (slot == PRAYER) {
+			prayerPoints = level;
+		}
+		dynamicLevels[slot] = level;
+		if (restoration[slot] != null) {
+			restoration[slot].restart();
+		}
+		if (entity instanceof Player) {
+			PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, slot));
+		}
+	}
+
+	/**
+	 * Gets a dynamic level.
+	 * @param slot The skill id.
+	 * @return The dynamic level.
+	 */
+	public int getLevel(int slot, boolean discardAssist) {
+		if (!discardAssist) {
+			if (entity instanceof Player) {
+				final Player p = (Player) entity;
+				final AssistSession assist = p.getExtension(AssistSession.class);
+				if (assist != null && assist.getPlayer() != p) {
+					Player assister = assist.getPlayer();
+					int index = assist.getSkillIndex(slot);
+					if (index != -1 && !assist.isRestricted()) {
+						// System.out.println(index + ", " +
+						// assist.getSkills()[index] + ", " + SKILL_NAME[slot]);
+						if (assist.getSkills()[index]) {
+							int assistLevel = assister.getSkills().getLevel(slot);
+							int playerLevel = dynamicLevels[slot];
+							if (assistLevel > playerLevel) {
+								return assistLevel;
+							}
 						}
 					}
 				}
 			}
 		}
+		return dynamicLevels[slot];
 	}
-	return dynamicLevels[slot];
-}
 
-/**
- * Gets the level.
- * @param slot the slot.
- * @return the level.
- */
-public int getLevel(int slot) {
-	return getLevel(slot, false);
-}
-
-/**
- * Sets the current amount of lifepoints.
- * @param lifepoints The lifepoints.
- */
-public void setLifepoints(int lifepoints) {
-	this.lifepoints = lifepoints;
-	if (this.lifepoints < 0) {
-		this.lifepoints = 0;
+	/**
+	 * Gets the level.
+	 * @param slot the slot.
+	 * @return the level.
+	 */
+	public int getLevel(int slot) {
+		return getLevel(slot, false);
 	}
-	lifepointsUpdate = true;
-}
 
-/**
- * Gets the lifepoints.
- * @return The lifepoints.
- */
-public int getLifepoints() {
-	return lifepoints;
-}
-
-/**
- * Gets the maximum amount of lifepoints.
- * @return The maximum amount.
- */
-public int getMaximumLifepoints() {
-	return staticLevels[HITPOINTS] + lifepointsIncrease;
-}
-
-/**
- * Sets the amount of lifepoints increase.
- * @param amount The amount.
- */
-public void setLifepointsIncrease(int amount) {
-	this.lifepointsIncrease = amount;
-}
-
-/**
- * Adds lifepoints to the entity.
- * @param health The amount to add.
- * @return The amount of overflow.
- */
-public int heal(int health) {
-	lifepoints += health;
-	int left = 0;
-	if (lifepoints > getMaximumLifepoints()) {
-		left = lifepoints - getMaximumLifepoints();
-		lifepoints = getMaximumLifepoints();
+	/**
+	 * Sets the current amount of lifepoints.
+	 * @param lifepoints The lifepoints.
+	 */
+	public void setLifepoints(int lifepoints) {
+		this.lifepoints = lifepoints;
+		if (this.lifepoints < 0) {
+			this.lifepoints = 0;
+		}
+		lifepointsUpdate = true;
 	}
-	lifepointsUpdate = true;
-	return left;
-}
 
-/**
- * @Deprecated Use
- * {@link ImpactHandler#manualHit(Entity, int, ImpactHandler.HitsplatType)}
- * or <br> the <b>hitsplat WILL NOT show and combat will be
- * desynchronized!</b>
- * @param damage The amount to remove.
- * @return The amount of overflow.
- */
-public int hit(int damage) {
-	lifepoints -= damage;
-	int left = 0;
-	if (lifepoints < 0) {
-		left = -lifepoints;
-		lifepoints = 0;
+	/**
+	 * Gets the lifepoints.
+	 * @return The lifepoints.
+	 */
+	public int getLifepoints() {
+		return lifepoints;
 	}
-	lifepointsUpdate = true;
-	return left;
-}
 
-/**
- * Gets the prayer points.
- * @return The prayer points.
- */
-public double getPrayerPoints() {
-	return prayerPoints;
-}
+	/**
+	 * Gets the maximum amount of lifepoints.
+	 * @return The maximum amount.
+	 */
+	public int getMaximumLifepoints() {
+		return staticLevels[HITPOINTS] + lifepointsIncrease;
+	}
 
-/**
- * Recharges the prayer points.
- */
-public void rechargePrayerPoints() {
-	prayerPoints = staticLevels[PRAYER];
-	if (entity instanceof Player) {
-		PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, PRAYER));
+	/**
+	 * Sets the amount of lifepoints increase.
+	 * @param amount The amount.
+	 */
+	public void setLifepointsIncrease(int amount) {
+		this.lifepointsIncrease = amount;
 	}
-}
 
-/**
- * Updates the current amount of prayer points (by decrementing).
- * @param amount The amount to decrement with.
- */
-public void decrementPrayerPoints(double amount) {
-	prayerPoints -= amount;
-	if (prayerPoints < 0) {
-		prayerPoints = 0;
+	/**
+	 * Adds lifepoints to the entity.
+	 * @param health The amount to add.
+	 * @return The amount of overflow.
+	 */
+	public int heal(int health) {
+		lifepoints += health;
+		int left = 0;
+		if (lifepoints > getMaximumLifepoints()) {
+			left = lifepoints - getMaximumLifepoints();
+			lifepoints = getMaximumLifepoints();
+		}
+		lifepointsUpdate = true;
+		return left;
 	}
-	// if (prayerPoints > staticLevels[PRAYER]) {
-	// prayerPoints = staticLevels[PRAYER];
-	// }
-	if (entity instanceof Player) {
-		PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, PRAYER));
-	}
-}
 
-/**
- * Updates the current amount of prayer points (by incrementing)
- * @param amount The amount to decrement with.
- */
-public void incrementPrayerPoints(double amount) {
-	prayerPoints += amount;
-	if (prayerPoints < 0) {
-		prayerPoints = 0;
+	/**
+	 * @Deprecated Use
+	 * {@link ImpactHandler#manualHit(Entity, int, ImpactHandler.HitsplatType)}
+	 * or <br> the <b>hitsplat WILL NOT show and combat will be
+	 * desynchronized!</b>
+	 * @param damage The amount to remove.
+	 * @return The amount of overflow.
+	 */
+	public int hit(int damage) {
+		lifepoints -= damage;
+		int left = 0;
+		if (lifepoints < 0) {
+			left = -lifepoints;
+			lifepoints = 0;
+		}
+		lifepointsUpdate = true;
+		return left;
 	}
-	if (prayerPoints > staticLevels[PRAYER]) {
+
+	/**
+	 * Gets the prayer points.
+	 * @return The prayer points.
+	 */
+	public double getPrayerPoints() {
+		return prayerPoints;
+	}
+
+	/**
+	 * Recharges the prayer points.
+	 */
+	public void rechargePrayerPoints() {
 		prayerPoints = staticLevels[PRAYER];
-	}
-	if (entity instanceof Player) {
-		PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, PRAYER));
-	}
-}
-
-/**
- * Sets the current prayer points (<b>without checking for being higher than
- * max</b>)
- * @param amount The amount.
- */
-public void setPrayerPoints(double amount) {
-	prayerPoints = amount;
-	if (entity instanceof Player) {
-		PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, PRAYER));
-	}
-}
-
-/**
- * Updates the current skill level (by incrementing the current amount with
- * the given amount, up to the given maximum).
- * @param skill The skill id.
- * @param amount The amount to increment.
- * @param maximum The maximum amount the skill can be.
- * @return The amount of "overflow".
- */
-public int updateLevel(int skill, int amount, int maximum) {
-	if (amount > 0 && dynamicLevels[skill] > maximum) {
-		return -amount;
-	}
-	int left = (dynamicLevels[skill] + amount) - maximum;
-	int level = dynamicLevels[skill] += amount;
-	if (level < 0) {
-		dynamicLevels[skill] = 0;
-	} else if (amount < 0 && level < maximum) {
-		dynamicLevels[skill] = maximum;
-	} else if (amount > 0 && level > maximum) {
-		dynamicLevels[skill] = maximum;
-	}
-	if (restoration[skill] != null) {
-		restoration[skill].restart();
-	}
-	if (entity instanceof Player) {
-		PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, skill));
-	}
-	return left;
-}
-
-/**
- * Updates a level.
- * @param skill the skill.
- * @param amount the amount.
- * @return the left.
- */
-public int updateLevel(int skill, int amount) {
-	return updateLevel(skill, amount, amount >= 0 ? getStaticLevel(skill) + amount : getStaticLevel(skill) - amount);
-}
-
-/**
- * Drains a certain percentage of a level.
- * @param skill The skill.
- * @param drainPercentage The drain percentage (0.05 indicates 5% drain).
- * @param maximumDrainPercentage The maximum drain percentage (0.05
- * indicates 5%).
- */
-public void drainLevel(int skill, double drainPercentage, double maximumDrainPercentage) {
-	int drain = (int) (dynamicLevels[skill] * drainPercentage);
-	int minimum = (int) (staticLevels[skill] * (1.0 - maximumDrainPercentage));
-	updateLevel(skill, -drain, minimum);
-}
-
-/**
- * Sets the static level.
- * @param skill The skill id.
- * @param level The level to set.
- */
-public void setStaticLevel(int skill, int level) {
-	experience[skill] = getExperienceByLevel(staticLevels[skill] = dynamicLevels[skill] = level);
-	if (entity instanceof Player) {
-		PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, skill));
-	}
-}
-
-/**
- * Gets the restoration pulses.
- * @return The restoration pulse array.
- */
-public SkillRestoration[] getRestoration() {
-	return restoration;
-}
-
-/**
- * Gets the amount of mastered skills.
- * @return The amount of mastered skills.
- */
-public int getMasteredSkills() {
-	int count = 0;
-	for (int i = 0; i < 23; i++) {
-		if (getStaticLevel(i) >= 99) {
-			count++;
+		if (entity instanceof Player) {
+			PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, PRAYER));
 		}
 	}
-	return count;
-}
 
-/**
- * Method used to get the skill by the name.
- * @param name the name.
- * @return the skill.
- */
-public static int getSkillByName(final String name) {
-	for (int i = 0; i < SKILL_NAME.length; i++) {
-		if (SKILL_NAME[i].equalsIgnoreCase(name)) {
-			return i;
+	/**
+	 * Updates the current amount of prayer points (by decrementing).
+	 * @param amount The amount to decrement with.
+	 */
+	public void decrementPrayerPoints(double amount) {
+		prayerPoints -= amount;
+		if (prayerPoints < 0) {
+			prayerPoints = 0;
+		}
+		// if (prayerPoints > staticLevels[PRAYER]) {
+		// prayerPoints = staticLevels[PRAYER];
+		// }
+		if (entity instanceof Player) {
+			PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, PRAYER));
 		}
 	}
-	return -1;
-}
 
-/**
- * Gets the total level.
- * @return the total level.
- */
-public int getTotalLevel() {
-	int level = 0;
-	for (int i = 0; i < 24; i++) {
-		level += getStaticLevel(i);
+	/**
+	 * Updates the current amount of prayer points (by incrementing)
+	 * @param amount The amount to decrement with.
+	 */
+	public void incrementPrayerPoints(double amount) {
+		prayerPoints += amount;
+		if (prayerPoints < 0) {
+			prayerPoints = 0;
+		}
+		if (prayerPoints > staticLevels[PRAYER]) {
+			prayerPoints = staticLevels[PRAYER];
+		}
+		if (entity instanceof Player) {
+			PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, PRAYER));
+		}
 	}
-	return level;
-}
 
-/**
- * Gets the lifepointsUpdate.
- * @return The lifepointsUpdate.
- */
-public boolean isLifepointsUpdate() {
-	return lifepointsUpdate;
-}
+	/**
+	 * Sets the current prayer points (<b>without checking for being higher than
+	 * max</b>)
+	 * @param amount The amount.
+	 */
+	public void setPrayerPoints(double amount) {
+		prayerPoints = amount;
+		if (entity instanceof Player) {
+			PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, PRAYER));
+		}
+	}
 
-/**
- * Sets the lifepointsUpdate.
- * @param lifepointsUpdate The lifepointsUpdate to set.
- */
-public void setLifepointsUpdate(boolean lifepointsUpdate) {
-	this.lifepointsUpdate = lifepointsUpdate;
-}
+	/**
+	 * Updates the current skill level (by incrementing the current amount with
+	 * the given amount, up to the given maximum).
+	 * @param skill The skill id.
+	 * @param amount The amount to increment.
+	 * @param maximum The maximum amount the skill can be.
+	 * @return The amount of "overflow".
+	 */
+	public int updateLevel(int skill, int amount, int maximum) {
+		if (amount > 0 && dynamicLevels[skill] > maximum) {
+			return -amount;
+		}
+		int left = (dynamicLevels[skill] + amount) - maximum;
+		int level = dynamicLevels[skill] += amount;
+		if (level < 0) {
+			dynamicLevels[skill] = 0;
+		} else if (amount < 0 && level < maximum) {
+			dynamicLevels[skill] = maximum;
+		} else if (amount > 0 && level > maximum) {
+			dynamicLevels[skill] = maximum;
+		}
+		if (restoration[skill] != null) {
+			restoration[skill].restart();
+		}
+		if (entity instanceof Player) {
+			PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, skill));
+		}
+		return left;
+	}
 
-/**
- * Gets the statis levels.
- * @return the level.
- */
-public int[] getStaticLevels() {
-	return staticLevels;
-}
+	/**
+	 * Updates a level.
+	 * @param skill the skill.
+	 * @param amount the amount.
+	 * @return the left.
+	 */
+	public int updateLevel(int skill, int amount) {
+		return updateLevel(skill, amount, amount >= 0 ? getStaticLevel(skill) + amount : getStaticLevel(skill) - amount);
+	}
 
-/**
- * Checks if the player has the required level.
- * @param skillId the skill id.
- * @param i the level.
- * @return {@code True} if so.
- */
-public boolean hasLevel(int skillId, int i) {
-	return getStaticLevel(skillId) >= i;
-}
+	/**
+	 * Drains a certain percentage of a level.
+	 * @param skill The skill.
+	 * @param drainPercentage The drain percentage (0.05 indicates 5% drain).
+	 * @param maximumDrainPercentage The maximum drain percentage (0.05
+	 * indicates 5%).
+	 */
+	public void drainLevel(int skill, double drainPercentage, double maximumDrainPercentage) {
+		int drain = (int) (dynamicLevels[skill] * drainPercentage);
+		int minimum = (int) (staticLevels[skill] * (1.0 - maximumDrainPercentage));
+		updateLevel(skill, -drain, minimum);
+	}
 
-/**
- * Gets the combatMilestone value.
- * @return The combatMilestone.
- */
-public int getCombatMilestone() {
-	return combatMilestone;
-}
+	/**
+	 * Sets the static level.
+	 * @param skill The skill id.
+	 * @param level The level to set.
+	 */
+	public void setStaticLevel(int skill, int level) {
+		experience[skill] = getExperienceByLevel(staticLevels[skill] = dynamicLevels[skill] = level);
+		if (entity instanceof Player) {
+			PacketRepository.send(SkillLevel.class, new SkillContext((Player) entity, skill));
+		}
+	}
 
-/**
- * Sets the combatMilestones value.
- * @param combatMilestone The combatMilestones to set.
- */
-public void setCombatMilestone(int combatMilestone) {
-	this.combatMilestone = combatMilestone;
-}
+	/**
+	 * Gets the restoration pulses.
+	 * @return The restoration pulse array.
+	 */
+	public SkillRestoration[] getRestoration() {
+		return restoration;
+	}
 
-/**
- * Gets the skillMilestone value.
- * @return The skillMilestone.
- */
-public int getSkillMilestone() {
-	return skillMilestone;
-}
+	/**
+	 * Gets the amount of mastered skills.
+	 * @return The amount of mastered skills.
+	 */
+	public int getMasteredSkills() {
+		int count = 0;
+		for (int i = 0; i < 23; i++) {
+			if (getStaticLevel(i) >= 99) {
+				count++;
+			}
+		}
+		return count;
+	}
 
-/**
- * Sets the skillMilestone value.
- * @param skillMilestone The skillMilestone to set.
- */
-public void setSkillMilestone(int skillMilestone) {
-	this.skillMilestone = skillMilestone;
-}
+	/**
+	 * Method used to get the skill by the name.
+	 * @param name the name.
+	 * @return the skill.
+	 */
+	public static int getSkillByName(final String name) {
+		for (int i = 0; i < SKILL_NAME.length; i++) {
+			if (SKILL_NAME[i].equalsIgnoreCase(name)) {
+				return i;
+			}
+		}
+		return -1;
+	}
 
-}
+	/**
+	 * Gets the total level.
+	 * @return the total level.
+	 */
+	public int getTotalLevel() {
+		int level = 0;
+		for (int i = 0; i < 24; i++) {
+			level += getStaticLevel(i);
+		}
+		return level;
+	}
+
+	/**
+	 * Gets the total exp.
+	 * @return the exp.
+	 */
+	public int getTotalXp() {
+		int total = 0;
+		for (int skill = 0; skill < Skills.SKILL_NAME.length; skill++) {
+			total += this.getExperience(skill);
+		}
+		return total;
+	}
+
+	/**
+	 * Gets the lifepointsUpdate.
+	 * @return The lifepointsUpdate.
+	 */
+	public boolean isLifepointsUpdate() {
+		return lifepointsUpdate;
+	}
+
+	/**
+	 * Sets the lifepointsUpdate.
+	 * @param lifepointsUpdate The lifepointsUpdate to set.
+	 */
+	public void setLifepointsUpdate(boolean lifepointsUpdate) {
+		this.lifepointsUpdate = lifepointsUpdate;
+	}
+
+	/**
+	 * Gets the statis levels.
+	 * @return the level.
+	 */
+	public int[] getStaticLevels() {
+		return staticLevels;
+	}
+
+	/**
+	 * Checks if the player has the required level.
+	 * @param skillId the skill id.
+	 * @param i the level.
+	 * @return {@code True} if so.
+	 */
+	public boolean hasLevel(int skillId, int i) {
+		return getStaticLevel(skillId) >= i;
+	}
+
+	/**
+	 * Gets the combatMilestone value.
+	 * @return The combatMilestone.
+	 */
+	public int getCombatMilestone() {
+		return combatMilestone;
+	}
+
+	/**
+	 * Sets the combatMilestones value.
+	 * @param combatMilestone The combatMilestones to set.
+	 */
+	public void setCombatMilestone(int combatMilestone) {
+		this.combatMilestone = combatMilestone;
+	}
+
+	/**
+	 * Gets the skillMilestone value.
+	 * @return The skillMilestone.
+	 */
+	public int getSkillMilestone() {
+		return skillMilestone;
+	}
+
+	/**
+	 * Sets the skillMilestone value.
+	 * @param skillMilestone The skillMilestone to set.
+	 */
+	public void setSkillMilestone(int skillMilestone) {
+		this.skillMilestone = skillMilestone;
+	}
+
+	}

--- a/Server/src/org/crandor/game/node/entity/player/Player.java
+++ b/Server/src/org/crandor/game/node/entity/player/Player.java
@@ -503,7 +503,7 @@ public class Player extends Entity {
 			String gender = this.isMale() ? "Man " : "Woman ";
 			Repository.sendNews("Hardcore Iron " + gender + " " + this.getUsername() +" has fallen. Total Level: " + this.getSkills().getTotalLevel()); // Not enough room for XP
 			this.getIronmanManager().setMode(IronmanMode.STANDARD);
-			asPlayer().getSavedData().getActivityData().setHardcoreDeath(1);
+			asPlayer().getSavedData().getActivityData().setHardcoreDeath(true);
 			this.sendMessage("You have fallen as a Hardcore Iron Man, your Hardcore status has been revoked.");
 		}
 

--- a/Server/src/org/crandor/game/node/entity/player/Player.java
+++ b/Server/src/org/crandor/game/node/entity/player/Player.java
@@ -502,7 +502,8 @@ public class Player extends Entity {
 		if (this.getIronmanManager().getMode().equals(IronmanMode.HARDCORE)){ //if this was checkRestriction, ultimate irons would be moved to HARDCORE_DEAD as well
 			String gender = this.isMale() ? "Man " : "Woman ";
 			Repository.sendNews("Hardcore Iron " + gender + " " + this.getUsername() +" has fallen. Total Level: " + this.getSkills().getTotalLevel()); // Not enough room for XP
-			this.getIronmanManager().setMode(IronmanMode.HARDCORE_DEAD);
+			this.getIronmanManager().setMode(IronmanMode.STANDARD);
+			asPlayer().getSavedData().getActivityData().setHardcoreDeath(1);
 			this.sendMessage("You have fallen as a Hardcore Iron Man, your Hardcore status has been revoked.");
 		}
 

--- a/Server/src/org/crandor/game/node/entity/player/Player.java
+++ b/Server/src/org/crandor/game/node/entity/player/Player.java
@@ -202,7 +202,7 @@ public class Player extends Entity {
 	 * The saved data.
 	 */
 	private final SavedData savedData = new SavedData(this);
-	
+
 	/**
 	 * The request manager.
 	 */
@@ -282,17 +282,17 @@ public class Player extends Entity {
 	 * The boolean for the player playing.
 	 */
 	private boolean playing;
-	
-	 /**
-     * If the player is invisible.
-     */
-    private boolean invisible;
+
+	/**
+	 * If the player is invisible.
+	 */
+	private boolean invisible;
 
 	/**
 	 * If the player is artificial.
 	 */
 	protected boolean artificial;
-	
+
 	/**
 	 * The skiller tasks.
 	 */
@@ -325,12 +325,12 @@ public class Player extends Entity {
 		super.init();
 		LoginConfiguration.configureLobby(this);
 	}
-	
+
 	@Override
 	public void clear() {
 		clear(false);
 	}
-	
+
 	/**
 	 * Clears the player from the game.
 	 * @param force If we should force removal, a player engaged in combat will otherwise remain active until out of combat.
@@ -445,7 +445,7 @@ public class Player extends Entity {
 	public CombatSwingHandler getSwingHandler(boolean swing) {
 		CombatStyle style = getProperties().getCombatPulse().getStyle();
 		if (swing) {
-			int weaponId = equipment.getNew(3).getId();	
+			int weaponId = equipment.getNew(3).getId();
 			if (getProperties().getSpell() != null || getProperties().getAutocastSpell() != null) {
 				return CombatStyle.MAGIC.getSwingHandler();
 			}
@@ -497,9 +497,15 @@ public class Player extends Entity {
 			return;
 		}
 		getPacketDispatch().sendMessage("Oh dear, you are dead!");
-		if (this.getIronmanManager().checkRestriction(IronmanMode.ULTIMATE)){
-			Repository.sendNews("Ultimate ironman "+this.getUsername()+" has just perished.");
+
+		//If player was a Hardcore Ironman, announce that they died
+		if (this.getIronmanManager().getMode().equals(IronmanMode.HARDCORE)){ //if this was checkRestriction, ultimate irons would be moved to HARDCORE_DEAD as well
+			String gender = this.isMale() ? "Man " : "Woman ";
+			Repository.sendNews("Hardcore Iron " + gender + " " + this.getUsername() +" has fallen. Total Level: " + this.getSkills().getTotalLevel()); // Not enough room for XP
+			this.getIronmanManager().setMode(IronmanMode.HARDCORE_DEAD);
+			this.sendMessage("You have fallen as a Hardcore Iron Man, your Hardcore status has been revoked.");
 		}
+
 		packetDispatch.sendTempMusic(90);
 		if (!getZoneMonitor().handleDeath(killer) && (!getProperties().isSafeZone() && getZoneMonitor().getType() != ZoneType.SAFE.getId()) && getDetails().getRights() != Rights.ADMINISTRATOR) {
 			GroundItemManager.create(new Item(526), getLocation(), k);
@@ -536,10 +542,10 @@ public class Player extends Entity {
 			inventory.addAll(c[0]);
 			if (gravestone) {
 				graveManager.create(ticks, items);
-			    sendMessages("<col=990000>Because of your current gavestone, you have "+graveManager.getType().getDecay()+" minutes to get your items and", "<col=990000>equipment back after dying in combat.");	
+				sendMessages("<col=990000>Because of your current gavestone, you have "+graveManager.getType().getDecay()+" minutes to get your items and", "<col=990000>equipment back after dying in combat.");
 			}
 			familiarManager.dismiss();
-			
+
 		}
 		skullManager.setSkulled(false);
 		removeAttribute("combat-time");
@@ -694,7 +700,7 @@ public class Player extends Entity {
 	public void sendMessage(String message) {
 		sendMessages(message);
 	}
-	
+
 	/**
 	 * Sends a notification message.
 	 * @param message The message.
@@ -711,12 +717,12 @@ public class Player extends Entity {
 	public boolean hasPerk(Perks perk) {
 		return details.getShop().hasPerk(perk);
 	}
-	
+
 	public boolean spawnZone() {
 		return (getLocation().getX() > 3090 && getLocation().getY() < 3500
-		&& getLocation().getX() < 3099 && getLocation().getY() > 3487);
+				&& getLocation().getX() < 3099 && getLocation().getY() > 3487);
 	}
-	
+
 	/**
 	 * Checks if the player can spawn.
 	 * @return {@code True} if so.
@@ -751,7 +757,7 @@ public class Player extends Entity {
 			packetDispatch.sendMessage(string);
 		}
 	}
-	
+
 	/**
 	 * Grabs a players gender, using shorter amount of code
 	 */
@@ -762,7 +768,7 @@ public class Player extends Entity {
 		else
 			return false;
 	}
-	
+
 	/**
 	 * Sets the player details.
 	 * @param details The player details.
@@ -857,7 +863,7 @@ public class Player extends Entity {
 	public PlayerDetails getDetails() {
 		return details;
 	}
-	
+
 	/**
 	 * Gets the name.
 	 * @param display the display.
@@ -1120,7 +1126,7 @@ public class Player extends Entity {
 	 * Gets the houseManager.
 	 * @return The houseManager.
 	 */
-	public HouseManager getHouseManager() { 
+	public HouseManager getHouseManager() {
 		return houseManager;
 	}
 
@@ -1230,23 +1236,23 @@ public class Player extends Entity {
 	public EmoteManager getEmoteManager() {
 		return emoteManager;
 	}
-	
-    /**
-     * Gets the invisible.
-     * @return the invisible
-     */
-    public boolean isInvisible() {
-    	return invisible;
-    }
- 
-    /**
-     * Sets the invisible.
-     * @param invisible the invisible to set.
-     */
-    public void setInvisible(boolean invisible) {
-    	this.invisible = invisible;
-    }   
- 
+
+	/**
+	 * Gets the invisible.
+	 * @return the invisible
+	 */
+	public boolean isInvisible() {
+		return invisible;
+	}
+
+	/**
+	 * Sets the invisible.
+	 * @param invisible the invisible to set.
+	 */
+	public void setInvisible(boolean invisible) {
+		this.invisible = invisible;
+	}
+
 	@Override
 	public String getUsername() {
 		return StringUtils.formatDisplayName(getName());
@@ -1266,11 +1272,11 @@ public class Player extends Entity {
 	}
 
 
-    public String getCustomState() {
-    	return customState;
-    }
+	public String getCustomState() {
+		return customState;
+	}
 
-    public void setCustomState(String state)
+	public void setCustomState(String state)
 	{
 		this.customState = state;
 	}

--- a/Server/src/org/crandor/game/node/entity/player/link/ActivityData.java
+++ b/Server/src/org/crandor/game/node/entity/player/link/ActivityData.java
@@ -106,6 +106,11 @@ public final class ActivityData implements SavingModule {
 	private int fogRating;
 
 	/**
+	 * The death status of a Hardcore Iron Man
+	 */
+	private int hardcoreDeath;
+
+	/**
 	 * Constructs a new {@code ActivityInfo} {@code Object}.
 	 */
 	public ActivityData() {
@@ -154,6 +159,7 @@ public final class ActivityData implements SavingModule {
 		SavedData.save(buffer, solvedMazes, 18);
 		SavedData.save(buffer, fogRating, 19);
 		SavedData.save(buffer, borkKills, 20);
+		SavedData.save(buffer, hardcoreDeath, 21);
 		buffer.put((byte) 0);
 
 	}
@@ -230,6 +236,8 @@ public final class ActivityData implements SavingModule {
 			case 20:
 				borkKills = buffer.get();
 				break;
+			case 21:
+				hardcoreDeath = buffer.getInt();
 			}
 		}
 	}
@@ -627,5 +635,17 @@ public final class ActivityData implements SavingModule {
 	 */
 	public void setBorkKills(byte borkKills) {
 		this.borkKills = borkKills;
+	}
+
+	/**
+	 * gets the current value of an Hardcore Iron Man's death status
+	 * @return the value of a Hardcore Iron Man's death status
+	 */
+	public int getHardcoreDeath() {
+		return hardcoreDeath;
+	}
+
+	public void setHardcoreDeath(int hardcoreDeath) {
+		this.hardcoreDeath = hardcoreDeath;
 	}
 }

--- a/Server/src/org/crandor/game/node/entity/player/link/ActivityData.java
+++ b/Server/src/org/crandor/game/node/entity/player/link/ActivityData.java
@@ -108,7 +108,7 @@ public final class ActivityData implements SavingModule {
 	/**
 	 * The death status of a Hardcore Iron Man
 	 */
-	private int hardcoreDeath;
+	private boolean hardcoreDeath;
 
 	/**
 	 * Constructs a new {@code ActivityInfo} {@code Object}.
@@ -237,7 +237,8 @@ public final class ActivityData implements SavingModule {
 				borkKills = buffer.get();
 				break;
 			case 21:
-				hardcoreDeath = buffer.getInt();
+				hardcoreDeath = SavedData.getBoolean(buffer);
+				break;
 			}
 		}
 	}
@@ -641,11 +642,11 @@ public final class ActivityData implements SavingModule {
 	 * gets the current value of an Hardcore Iron Man's death status
 	 * @return the value of a Hardcore Iron Man's death status
 	 */
-	public int getHardcoreDeath() {
+	public boolean getHardcoreDeath() {
 		return hardcoreDeath;
 	}
 
-	public void setHardcoreDeath(int hardcoreDeath) {
+	public void setHardcoreDeath(boolean hardcoreDeath) {
 		this.hardcoreDeath = hardcoreDeath;
 	}
 }

--- a/Server/src/org/crandor/game/node/entity/player/link/IronmanMode.java
+++ b/Server/src/org/crandor/game/node/entity/player/link/IronmanMode.java
@@ -5,7 +5,9 @@ package org.crandor.game.node.entity.player.link;
  * @author Vexia
  */
 public enum IronmanMode {
-	NONE(-1), STANDARD(14), ULTIMATE(15);
+	//TODO: add HCIM logo to cache/wherever else it needs to go
+	// HARDCORE_DEAD has to be before Ultimate so that it does not adopt it's restrictions (on the basis of >= in IronmanManager.java)
+	NONE(-1), STANDARD(14), HARDCORE(16), HARDCORE_DEAD (14), ULTIMATE(15);
 
 	/**
 	 * The icon id.

--- a/Server/src/org/crandor/game/node/entity/player/link/IronmanMode.java
+++ b/Server/src/org/crandor/game/node/entity/player/link/IronmanMode.java
@@ -6,8 +6,8 @@ package org.crandor.game.node.entity.player.link;
  */
 public enum IronmanMode {
 	//TODO: add HCIM logo to cache/wherever else it needs to go
-	// HARDCORE_DEAD has to be before Ultimate so that it does not adopt it's restrictions (on the basis of >= in IronmanManager.java)
-	NONE(-1), STANDARD(14), HARDCORE(16), HARDCORE_DEAD (14), ULTIMATE(15);
+	// HARDCORE_DEAD has to be before Ultimate so that it does not adopt it's restrictions (on the basis of >= in IronmanManager.java?)
+	NONE(-1), STANDARD(14), HARDCORE(16), ULTIMATE(15);
 
 	/**
 	 * The icon id.

--- a/Server/src/org/crandor/game/system/mysql/impl/HighscoreSQLHandler.java
+++ b/Server/src/org/crandor/game/system/mysql/impl/HighscoreSQLHandler.java
@@ -59,7 +59,7 @@ public final class HighscoreSQLHandler extends SQLEntryHandler<Player> {
 			create();
 			return;
 		}
-		if (entry.getSavedData().getActivityData().getHardcoreDeath() == 1){
+		if (entry.getSavedData().getActivityData().getHardcoreDeath() == true){
 			//Update the SQL table to indicate the player was a Hardcore ironman that died, do not update hiscores
 			StringBuilder b = new StringBuilder("UPDATE highscores SET ironManMode='HARDCORE_DEAD' WHERE username ='" + value + "'");
 			PreparedStatement statement = connection.prepareStatement(b.toString());

--- a/Server/src/org/crandor/game/system/mysql/impl/HighscoreSQLHandler.java
+++ b/Server/src/org/crandor/game/system/mysql/impl/HighscoreSQLHandler.java
@@ -4,6 +4,7 @@ import org.crandor.ServerConstants;
 import org.crandor.game.content.skill.Skills;
 import org.crandor.game.node.entity.player.Player;
 import org.crandor.game.node.entity.player.info.Rights;
+import org.crandor.game.node.entity.player.link.IronmanMode;
 import org.crandor.game.system.mysql.SQLEntryHandler;
 import org.crandor.game.system.mysql.SQLManager;
 import org.crandor.game.world.GameWorld;
@@ -56,6 +57,15 @@ public final class HighscoreSQLHandler extends SQLEntryHandler<Player> {
 		super.read();
 		if (result == null || !result.next()) {
 			create();
+			return;
+		}
+		if (entry.getIronmanManager().checkRestriction(IronmanMode.HARDCORE_DEAD))
+		{
+			//Update the SQL table to indicate the player was a Hardcore ironman that died, do not update hiscores
+			StringBuilder b = new StringBuilder("UPDATE highscores SET ironManMode='" + entry.getIronmanManager().getMode().name() + "' WHERE username ='" + value +"'");
+			PreparedStatement statement = connection.prepareStatement(b.toString());
+			statement.executeUpdate();
+			SQLManager.close(statement.getConnection());
 			return;
 		}
 		StringBuilder b = new StringBuilder("UPDATE highscores SET overall_xp='" + getTotalXp() + "', total_level='" + entry.getSkills().getTotalLevel() + "', ironManMode='" + entry.getIronmanManager().getMode().name() + "', ");

--- a/Server/src/org/crandor/game/system/mysql/impl/HighscoreSQLHandler.java
+++ b/Server/src/org/crandor/game/system/mysql/impl/HighscoreSQLHandler.java
@@ -37,7 +37,7 @@ public final class HighscoreSQLHandler extends SQLEntryHandler<Player> {
 			return;
 		}
 		StringBuilder b = new StringBuilder("INSERT highscores(username,overall_xp,total_level,ironManMode,xp_0,xp_1,xp_2,xp_3,xp_4,xp_5,xp_6,xp_7,xp_8,xp_9,xp_10,xp_11,xp_12,xp_13,xp_14,xp_15,xp_16,xp_17,xp_18,xp_19,xp_20,xp_21,xp_22,xp_23) ");
-		b.append("VALUES('" + value + "', '" + getTotalXp() + "', '" + entry.getSkills().getTotalLevel() + "', '" + entry.getIronmanManager().getMode().name() + "', ");
+		b.append("VALUES('" + value + "', '" + entry.getSkills().getTotalXp() + "', '" + entry.getSkills().getTotalLevel() + "', '" + entry.getIronmanManager().getMode().name() + "', ");
 		int xp;
 		for (int i = 0; i < Skills.SKILL_NAME.length; i++) {
 			xp = (int) entry.getSkills().getExperience(i);
@@ -59,16 +59,15 @@ public final class HighscoreSQLHandler extends SQLEntryHandler<Player> {
 			create();
 			return;
 		}
-		if (entry.getIronmanManager().checkRestriction(IronmanMode.HARDCORE_DEAD))
-		{
+		if (entry.getSavedData().getActivityData().getHardcoreDeath() == 1){
 			//Update the SQL table to indicate the player was a Hardcore ironman that died, do not update hiscores
-			StringBuilder b = new StringBuilder("UPDATE highscores SET ironManMode='" + entry.getIronmanManager().getMode().name() + "' WHERE username ='" + value +"'");
+			StringBuilder b = new StringBuilder("UPDATE highscores SET ironManMode='HARDCORE_DEAD' WHERE username ='" + value + "'");
 			PreparedStatement statement = connection.prepareStatement(b.toString());
 			statement.executeUpdate();
 			SQLManager.close(statement.getConnection());
 			return;
 		}
-		StringBuilder b = new StringBuilder("UPDATE highscores SET overall_xp='" + getTotalXp() + "', total_level='" + entry.getSkills().getTotalLevel() + "', ironManMode='" + entry.getIronmanManager().getMode().name() + "', ");
+		StringBuilder b = new StringBuilder("UPDATE highscores SET overall_xp='" + entry.getSkills().getTotalXp() + "', total_level='" + entry.getSkills().getTotalLevel() + "', ironManMode='" + entry.getIronmanManager().getMode().name() + "', ");
 		int xp;
 		for (int i = 0; i < Skills.SKILL_NAME.length; i++) {
 			xp = (int) entry.getSkills().getExperience(i);
@@ -95,18 +94,6 @@ public final class HighscoreSQLHandler extends SQLEntryHandler<Player> {
 	@Override
 	public Connection getConnection() {
 		return SQLManager.getConnection();
-	}
-
-	/**
-	 * Gets the total exp.
-	 * @return the exp.
-	 */
-	public int getTotalXp() {
-		int total = 0;
-		for (int skill = 0; skill < Skills.SKILL_NAME.length; skill++) {
-			total += entry.getSkills().getExperience(skill);
-		}
-		return total;
 	}
 
 }

--- a/Server/src/plugin/command/PlayerCommandPlugin.java
+++ b/Server/src/plugin/command/PlayerCommandPlugin.java
@@ -68,7 +68,7 @@ public final class PlayerCommandPlugin extends CommandPlugin {
 					player.sendChat("Hey, everyone, I just tried to do something very silly!");
 				}
 				break;
-				
+
 			case "bankresettabs":
 				for (int i = 0; i < player.getBank().getTabStartSlot().length; i++) {
 					player.getBank().getTabStartSlot()[i] = 0;
@@ -79,7 +79,7 @@ public final class PlayerCommandPlugin extends CommandPlugin {
 				}
 				player.sendMessage("<col=3498db>Your bank tabs have been reset!");
 				return true;
-				
+
 			case "bankresetpin":
 				if (arguments.length < 2) {
 					player.sendMessage("<col=e74c3c>You must specify your current pin!");
@@ -104,25 +104,29 @@ public final class PlayerCommandPlugin extends CommandPlugin {
 			case "players":
 				int totalCount = Repository.getPlayers().size();
 				int ironmanCount = 0;
+				int hardcoreIronmanCount = 0;
 				int ultIronmanCount = 0;
 				int botCount = 0;
 				for (Player p : Repository.getPlayers()) {
-					if (p.getIronmanManager().checkRestriction(IronmanMode.ULTIMATE)) {
-						ultIronmanCount++;
+					if (p.getIronmanManager().getMode().equals(IronmanMode.ULTIMATE)) { //If this was check restriction, ultimate irons would be counted as all
+						ultIronmanCount++;												//three modes, affecting the player count
 					}
-					if (p.getIronmanManager().checkRestriction(IronmanMode.STANDARD)) {
+					else if (p.getIronmanManager().getMode().equals(IronmanMode.HARDCORE)) {
+						hardcoreIronmanCount++;
+					}
+					else if (p.getIronmanManager().getMode().equals(IronmanMode.STANDARD) ||p.getIronmanManager().getMode().equals(IronmanMode.HARDCORE_DEAD)) {
 						ironmanCount++;
 					}
 					if (p.isArtificial()){
 						botCount++;
 					}
 				}
-				int regular = totalCount - ironmanCount - ultIronmanCount - botCount;
+				int regular = totalCount - ironmanCount - hardcoreIronmanCount - ultIronmanCount - botCount;
 				int playerCount = totalCount-botCount;
 				if (totalCount == 1) {
 					player.sendMessage("<col=3498db>There is 1 active player in this world.");
 				} else {
-					player.sendMessage("<col=3498db>There are " + playerCount + " active players in this world: " + regular + " regular, " + ironmanCount + " iron, and " + ultIronmanCount + " ultimate iron.");
+					player.sendMessage("<col=3498db>There are " + playerCount + " active players in this world: " + regular + " regular, " + ironmanCount + " IM, " + hardcoreIronmanCount + " HCIM, " + ultIronmanCount + " UIM.");
 				}
 				return player.getRights() == Rights.REGULAR_PLAYER;
 

--- a/Server/src/plugin/command/PlayerCommandPlugin.java
+++ b/Server/src/plugin/command/PlayerCommandPlugin.java
@@ -114,7 +114,7 @@ public final class PlayerCommandPlugin extends CommandPlugin {
 					else if (p.getIronmanManager().getMode().equals(IronmanMode.HARDCORE)) {
 						hardcoreIronmanCount++;
 					}
-					else if (p.getIronmanManager().getMode().equals(IronmanMode.STANDARD) ||p.getIronmanManager().getMode().equals(IronmanMode.HARDCORE_DEAD)) {
+					else if (p.getIronmanManager().getMode().equals(IronmanMode.STANDARD)) {
 						ironmanCount++;
 					}
 					if (p.isArtificial()){

--- a/Server/src/plugin/dialogue/HansDialoguePlugin.java
+++ b/Server/src/plugin/dialogue/HansDialoguePlugin.java
@@ -151,7 +151,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 			case 100:
 				switch (buttonId) {
 					case 1: //no longer want to be iron
-						if (player.getIronmanManager().checkRestriction(IronmanMode.HARDCORE_DEAD)) {
+						if (player.getSavedData().getActivityData().getHardcoreDeath() == 1) {
 							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you've fallen as a Hardcore Iron Man", "already. It would be unfair for those with other", " restrictions if your status were to be removed!");
 							stage = 50;
 							break;
@@ -168,7 +168,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 							break;
 						}
 					case 2: //change ironman mode
-						if (player.getIronmanManager().checkRestriction(IronmanMode.HARDCORE_DEAD)) {
+						if (player.getSavedData().getActivityData().getHardcoreDeath() == 1) {
 							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you've fallen as a Hardcore Iron Man", "already. It would be unfair for those with other", " restrictions if your status were to be changed!");
 							stage = 50;
 							break;

--- a/Server/src/plugin/dialogue/HansDialoguePlugin.java
+++ b/Server/src/plugin/dialogue/HansDialoguePlugin.java
@@ -151,7 +151,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 			case 100:
 				switch (buttonId) {
 					case 1: //no longer want to be iron
-						if (player.getSavedData().getActivityData().getHardcoreDeath() == 1) {
+						if (player.getSavedData().getActivityData().getHardcoreDeath() == true) {
 							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you've fallen as a Hardcore Iron Man", "already. It would be unfair for those with other", " restrictions if your status were to be removed!");
 							stage = 50;
 							break;
@@ -168,7 +168,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 							break;
 						}
 					case 2: //change ironman mode
-						if (player.getSavedData().getActivityData().getHardcoreDeath() == 1) {
+						if (player.getSavedData().getActivityData().getHardcoreDeath() == true) {
 							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you've fallen as a Hardcore Iron Man", "already. It would be unfair for those with other", " restrictions if your status were to be changed!");
 							stage = 50;
 							break;

--- a/Server/src/plugin/dialogue/HansDialoguePlugin.java
+++ b/Server/src/plugin/dialogue/HansDialoguePlugin.java
@@ -3,6 +3,7 @@ package plugin.dialogue;
 import org.crandor.game.content.dialogue.DialoguePlugin;
 import org.crandor.game.content.dialogue.FacialExpression;
 import org.crandor.game.node.entity.npc.NPC;
+import org.crandor.game.node.entity.player.link.IronmanMode;
 import org.crandor.plugin.InitializablePlugin;
 import org.crandor.game.node.entity.player.Player;
 
@@ -51,7 +52,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 
 		switch (stage) {
 			case 0:
-				interpreter.sendOptions("Select an Option", "I'm looking for whoever is in charge of this place.", "I have come to kill everyone in this castle!", "I don't know. I'm lost. Where am I?", "Have you been here as long as me?", "I'd like to learn faster!");
+				interpreter.sendOptions("Select an Option", "I'm looking for whoever is in charge of this place.", "I have come to kill everyone in this castle!", "I don't know. I'm lost. Where am I?", "More Options...");
 				stage++;
 				break;
 			case 1:
@@ -72,60 +73,220 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 						stage = 50;
 						break;
 					case 4:
-						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "I've been patrolling this castle for years!");
-						stage = 40;
+						interpreter.sendOptions("Select an Option", "Have you been here as long as me?", "I'd like to learn faster!", "About Iron Man mode...", "Go Back...");
+						stage = 10;
 						break;
-					case 5:
-						if (player.getSkills().experienceMutiplier == 15.0) {
-							interpreter.sendDialogues(npc, FacialExpression.OSRS_NORMAL, "Sorry, but you're already at the fastest experience", "rate. It's only a one way operation, and", "you can't learn faster yet I'm afraid!");
+				}
+				break;
+			case 10:
+				switch (buttonId) {
+					case 1:
+						//Have you been here as long as me?
+						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "I've been patrolling this castle for years!");
+						stage = 41;
+						break;
+					case 2:
+						//I'd Like to Learn Faster
+						if (player.getSkills().experienceMutiplier == 10.0) {
+							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you're already at the fastest experience", "rate. It's only a one way operation, and", "you can't learn faster yet I'm afraid!");
 							stage = 50;
 						} else {
 							interpreter.sendDialogues(npc, FacialExpression.HAPPY, "That's great! I can help you with that, but", "I must warn you it's only a one-way thing. There's no", "going back!");
-							stage = 150;
+							stage = 200;
 						}
 						break;
+					case 3:
+						//About Iron Man Mode...
+						if (player.getIronmanManager().isIronman())
+						{
+							interpreter.sendOptions("Select an Option", "I no longer want to be an Iron Man", "I'd like to change my Iron Man mode", "What is an Iron Man?", "Go Back...");
+							stage = 100;
+						} else {
+							interpreter.sendOptions("Select an Option", "I would like to be an Iron Man.", "What is an Iron Man?", "Go Back...");
+							stage = 110;
+						}
+						break;
+					case 4: // Go back
+						interpreter.sendOptions("Select an Option", "I'm looking for whoever is in charge of this place.", "I have come to kill everyone in this castle!", "I don't know. I'm lost. Where am I?", "More Options...");
+						stage = 1;
+						break;
 				}
-
 				break;
-			case 40:
+
+			//Have you been here as long as me?
+			case 41:
 				interpreter.sendDialogues(player, FacialExpression.THINKING, "You must be old then?");
 				stage++;
 				break;
-			case 41:
+			case 42:
 				interpreter.sendDialogues(npc, FacialExpression.LAUGH, "Haha, you could say I'm quite the veteran of these lands.", "Yes, I've been here a fair while...");
 				stage++;
 				break;
-			case 42: //mixing OSRS here
+			case 43: //mixing OSRS here
 				interpreter.sendDialogues(player, FacialExpression.ASKING, "Can you tell me how long I've been here?");
 				stage++;
 				break;
-			case 43:
+			case 44:
 				interpreter.sendDialogues(npc, FacialExpression.FRIENDLY, "Ahh, I see all the newcomers arriving in Lumbridge, fresh-faced ","and eager for adventure. I remember you...");
+				player.sendMessage("Feature not currently available.");
 				stage = 50;
 				break;
-		/*case 44:
-			getTimePlayed();
+			/*case 45:
+				getTimePlayed();
 
-			//The text:
-			//NOTE: it splits the text in different spots if the hours/minutes/days are 0 (because 0 days sounds weird, so it doesn't show it).
+				//The text:
+				//NOTE: it splits the text in different spots if the hours/minutes/days are 0 (because 0 days sounds weird, so it doesn't show it).
 
-			//You've spent [amount] days, [amount] hours, [amount] minutes in the world (NEXT LINE) since you arrived [amount] days ago.
-			//You've spent [amount] (days/hours), [amount] (hours/minutes) in the world since (NEXT LINE) you arrived [amount] days ago.
-			//You've spent [amount] (days/hours/minutes) in the world since you arrived (NEXT LINE) [amount] days ago.
-		*/
+				//You've spent [amount] days, [amount] hours, [amount] minutes in the world (NEXT LINE) since you arrived [amount] days ago.
+				//You've spent [amount] (days/hours), [amount] (hours/minutes) in the world since (NEXT LINE) you arrived [amount] days ago.
+				//You've spent [amount] (days/hours/minutes) in the world since you arrived (NEXT LINE) [amount] days ago.
+			*/
 
 			//Closing Chat
 			case 50:
 				end();
 				break;
-			case 150:
-				interpreter.sendOptions("Select an Option", "Set my exp rate to 10x", "Nevermind");
+
+			//About Iron Man Mode...
+			case 100:
+				switch (buttonId) {
+					case 1: //no longer want to be iron
+						if (player.getIronmanManager().checkRestriction(IronmanMode.HARDCORE_DEAD)) {
+							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you've fallen as a Hardcore Iron Man", "already. It would be unfair for those with other", " restrictions if your status were to be removed!");
+							stage = 50;
+							break;
+						}
+						if (player.getSkills().getTotalLevel() > 500 || player.getQuestRepository().getPoints() > 10){
+							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you are too far along your journey.", "It would be unfair for those with other", " restrictions if your status were to be removed!");
+							stage = 50;
+							break;
+						} else {
+							interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "I have removed your Iron Man status.");
+							player.getIronmanManager().setMode(IronmanMode.NONE);
+							player.sendMessage("Your Iron Man status has been removed.");
+							stage = 50;
+							break;
+						}
+					case 2: //change ironman mode
+						if (player.getIronmanManager().checkRestriction(IronmanMode.HARDCORE_DEAD)) {
+							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you've fallen as a Hardcore Iron Man", "already. It would be unfair for those with other", " restrictions if your status were to be changed!");
+							stage = 50;
+							break;
+						}
+						if (player.getSkills().getTotalLevel() > 500 || player.getQuestRepository().getPoints() > 10){
+							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you are too far along your journey.", "It would be unfair for those with other", " restrictions if your status were to be changed!");
+							stage = 50;
+							break;
+						} else {
+							interpreter.sendOptions("Select a Mode", "Standard", "<col=8A0808>Hardcore</col>", "<col=ECEBEB>Ultimate</col>", "Nevermind.");
+							stage = 150;
+							break;
+						}
+					case 3: // What is Iron Man Mode?
+						player("What is an Iron Man?");
+						stage = 120;
+						break;
+					case 4: //Go back.
+						interpreter.sendOptions("Select an Option", "Have you been here as long as me?", "I'd like to learn faster!", "About Iron Man mode...", "Go Back...");
+						stage = 10;
+						break;
+				}
+				break;
+			case 110:
+				switch (buttonId) {
+					case 1: //I would like to be an Iron Man
+						if (player.getSkills().getTotalLevel() > 500 || player.getQuestRepository().getPoints() > 10){
+							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but you are too far along your journey.", "It would be unfair for those with other", " restrictions if your status were to be changed!");
+							stage = 50;
+							break;
+						} else {
+							interpreter.sendOptions("Select a Mode", "Standard", "<col=8A0808>Hardcore</col>", "<col=ECEBEB>Ultimate</col>", "Nevermind.");
+							stage = 150;
+							break;
+						}
+					case 2: // What is Iron Man Mode?
+						player("What is an Iron Man?");
+						stage = 120;
+						break;
+					case 3: //Go back.
+						interpreter.sendOptions("Select an Option", "Have you been here as long as me?", "I'd like to learn faster!", "About Iron Man mode...", "Go Back...");
+						stage = 10;
+						break;
+				}
+				break;
+
+			//What is an Iron Man?
+			case 120:
+				npc("An Iron Man account is a style of playing where players", "are completely self-sufficient.");
 				stage++;
 				break;
-			case 151:
+			case 121:
+				npc("A Standard Ironman does not receive items or", "assistance from other players. They cannot trade, stake,", "receive PK loot, scavenge dropped items, nor play", "certain minigames.");
+				stage++;
+				break;
+			case 122:
+				npc("In addition to Standard Ironman restrictions,", "<col=8A0808>Hardcore</col> Ironmen only have one life. In the event of","a dangerous death, a player will be downgraded to a", "Standard Ironman, and their stats frozen on the hiscores.");
+				stage++;
+				break;
+			case 123:
+				npc("For the ultimate challenge, players who choose the", "<col=ECEBEB>Ultimate</col> Ironman mode cannot use banks, nor", "retain any items on death in dangerous areas.");
+				stage++;
+				break;
+			case 124:
+				if (player.getIronmanManager().isIronman()) {
+					interpreter.sendOptions("Select an Option", "I no longer want to be an Iron Man", "I'd like to change my Iron Man mode", "What is an Iron Man?", "Go Back.");
+					stage = 100;
+				} else {
+					interpreter.sendOptions("Select an Option", "I would like to be an Iron Man.", "What is an Iron Man?", "Go Back...");
+					stage = 110;
+				}
+				break;
+
+			//Change Iron man mode dialogue/code
+			case 150:
+				switch(buttonId){
+					case 1:
+					case 2:
+						npc("I have changed your Iron Man mode to: ","" + (buttonId == 1 ? "Standard" : "<col=8A0808>Hardcore</col>" + " Ironman mode."));
+						player.getIronmanManager().setMode(IronmanMode.values()[buttonId]);
+						player.sendMessage("Your Iron Man status has been changed.");
+						stage = 50;
+						break;
+					case 3: //ultimate ironman
+						if (!player.getBank().isEmpty())
+						{
+							interpreter.sendDialogues(npc, FacialExpression.GUILTY, "Sorry, but your bank is has items in it.", "Please empty your bank and speak to me again.");
+							stage = 50;
+							break;
+						} else{
+							npc("I have changed your Iron Man mode to:","<col=ECEBEB>Ultimate</col> Ironman mode.");
+							player.getIronmanManager().setMode(IronmanMode.ULTIMATE);
+							player.sendMessage("Your Iron Man status has been changed.");
+							stage = 50;
+							break;
+						}
+					case 4:
+						if (player.getIronmanManager().isIronman()) {
+							interpreter.sendOptions("Select an Option", "I no longer want to be an Iron Man", "I'd like to change my Iron Man mode", "What is an Iron Man?", "Go Back...");
+							stage = 100;
+						} else {
+							interpreter.sendOptions("Select an Option", "I would like to be an Iron Man.", "What is an Iron Man?", "Go Back...");
+							stage = 110;
+						}
+						break;
+				}
+				break;
+
+
+			//About XP Multiplier
+			case 200:
+				interpreter.sendOptions("Select an Option", "Set my experience rate to 10x", "Nevermind.");
+				stage++;
+				break;
+			case 201:
 				switch (buttonId) {
 					case 1:
-						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "Tada! Your experience rate is now 15x.", "Happy Scaping!");
+						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "Tada! Your experience rate is now 10x.", "Happy Scaping!");
 						player.getSkills().experienceMutiplier = 10.0;
 						stage = 50;
 						break;
@@ -133,7 +294,6 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 					    end();
 						break;
 				}
-
 				break;
 		}
 

--- a/Server/src/plugin/dialogue/HansDialoguePlugin.java
+++ b/Server/src/plugin/dialogue/HansDialoguePlugin.java
@@ -183,7 +183,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 							break;
 						}
 					case 3: // What is Iron Man Mode?
-						player("What is an Iron Man?");
+						interpreter.sendDialogues(player, FacialExpression.ASKING,"What is an Iron Man?");
 						stage = 120;
 						break;
 					case 4: //Go back.
@@ -217,19 +217,19 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 
 			//What is an Iron Man?
 			case 120:
-				npc("An Iron Man account is a style of playing where players", "are completely self-sufficient.");
+				interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"An Iron Man account is a style of playing where players", "are completely self-sufficient.");
 				stage++;
 				break;
 			case 121:
-				npc("A Standard Ironman does not receive items or", "assistance from other players. They cannot trade, stake,", "receive PK loot, scavenge dropped items, nor play", "certain minigames.");
+				interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"A Standard Ironman does not receive items or", "assistance from other players. They cannot trade, stake,", "receive PK loot, scavenge dropped items, nor play", "certain minigames.");
 				stage++;
 				break;
 			case 122:
-				npc("In addition to Standard Ironman restrictions,", "<col=8A0808>Hardcore</col> Ironmen only have one life. In the event of","a dangerous death, a player will be downgraded to a", "Standard Ironman, and their stats frozen on the hiscores.");
+				interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"In addition to Standard Ironman restrictions,", "<col=8A0808>Hardcore</col> Ironmen only have one life. In the event of","a dangerous death, a player will be downgraded to a", "Standard Ironman, and their stats frozen on the hiscores.");
 				stage++;
 				break;
 			case 123:
-				npc("For the ultimate challenge, players who choose the", "<col=ECEBEB>Ultimate</col> Ironman mode cannot use banks, nor", "retain any items on death in dangerous areas.");
+				interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"For the ultimate challenge, players who choose the", "<col=ECEBEB>Ultimate</col> Ironman mode cannot use banks, nor", "retain any items on death in dangerous areas.");
 				stage++;
 				break;
 			case 124:
@@ -247,7 +247,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 				switch(buttonId){
 					case 1:
 					case 2:
-						npc("I have changed your Iron Man mode to: ","" + (buttonId == 1 ? "Standard" : "<col=8A0808>Hardcore</col>" + " Ironman mode."));
+						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"I have changed your Iron Man mode to: ","" + (buttonId == 1 ? "Standard" : "<col=8A0808>Hardcore</col>" + " Ironman mode."));
 						player.getIronmanManager().setMode(IronmanMode.values()[buttonId]);
 						player.sendMessage("Your Iron Man status has been changed.");
 						stage = 50;
@@ -259,7 +259,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 							stage = 50;
 							break;
 						} else{
-							npc("I have changed your Iron Man mode to:","<col=ECEBEB>Ultimate</col> Ironman mode.");
+							interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"I have changed your Iron Man mode to:","<col=ECEBEB>Ultimate</col> Ironman mode.");
 							player.getIronmanManager().setMode(IronmanMode.ULTIMATE);
 							player.sendMessage("Your Iron Man status has been changed.");
 							stage = 50;
@@ -286,7 +286,7 @@ public final class HansDialoguePlugin extends DialoguePlugin {
 			case 201:
 				switch (buttonId) {
 					case 1:
-						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "Tada! Your experience rate is now 10x.", "Happy Scaping!");
+						interpreter.sendDialogues(npc, FacialExpression.FRIENDLY, "Tada! Your experience rate is now 10x.", "Happy Scaping!");
 						player.getSkills().experienceMutiplier = 10.0;
 						stage = 50;
 						break;

--- a/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
+++ b/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
@@ -74,11 +74,11 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 		if (npc.getId() == 946) {
 			switch (TutorialSession.getExtension(player).getStage()) {
 				case 67:
-					interpreter.sendDialogues(player, null, "Hello.");
+					interpreter.sendDialogues(player, FacialExpression.FRIENDLY, "Hello.");
 					stage = 0;
 					return true;
 				case 69:
-					interpreter.sendDialogues(946, null, "Good. This is a list of your spells. Currently you can", "only cast one offensive spell called Wind Strike. Let's", "try it out on one of those chickens.");
+					interpreter.sendDialogues(946, FacialExpression.NEUTRAL, "Good. This is a list of your spells. Currently you can", "only cast one offensive spell called Wind Strike. Let's", "try it out on one of those chickens.");
 					stage = 0;
 					return true;
 				case 70:
@@ -97,7 +97,7 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 					}
 					return true;
 				case 71:
-					interpreter.sendDialogues(946, null, "Well you're all finished here now. I'll give you a", "reasonable number of runes when you leave.");
+					interpreter.sendDialogues(946, FacialExpression.NEUTRAL, "Well you're all finished here now. I'll give you a", "reasonable number of runes when you leave.");
 					stage = -2;
 					return true;
 			}
@@ -105,7 +105,7 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 
 		//Skippy Dialogue used whenever the Player talks to Skippy during the tutorial
 		else {
-			interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "*psst.* Hey, do you want to skip the tutorial?", "I can send you straight to the mainland, easy.");
+			interpreter.sendDialogues(npc, FacialExpression.SUSPICIOUS, "*psst.* Hey, do you want to skip the tutorial?", "I can send you straight to the mainland, easy.");
 			stage = 1;
 		}
 		return true;
@@ -124,7 +124,7 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 				case -1:
 					switch (buttonId) {
 						case 1:
-							npc("One more thing: Would you like to", "be an Ironman account?");
+							interpreter.sendDialogues(npc, FacialExpression.ASKING,"One more thing: Would you like to", "be an Ironman account?");
 							stage = 501;
 							break;
 						case 2:
@@ -142,28 +142,28 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 				case 2:
 					switch (buttonId) {
 						case 1:
-							npc("One more thing: Would you like to", "be an Ironman account?");
+							interpreter.sendDialogues(npc, FacialExpression.ASKING,"One more thing: Would you like to", "be an Ironman account?");
 							stage = 501;
 							if (!IRONMAN) {
 								stage = 1205;
 							}
 							break;
 						case 2:
-							interpreter.sendDialogues(player, FacialExpression.HALF_GUILTY, "Can I decide later?.");
+							interpreter.sendDialogues(player, FacialExpression.THINKING, "Can I decide later?.");
 							stage = 39;
 							break;
 						case 3:
-							interpreter.sendDialogues(player, FacialExpression.HALF_GUILTY, "I'll stay here for the Tutorial.");
+							interpreter.sendDialogues(player, FacialExpression.NEUTRAL, "I'll stay here for the Tutorial.");
 							stage = 40;
 							break;
 					}
 					break;
 				case 39:
-					interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "Yes. Talk to me at any point during this tutorial", "if you change your mind.");
+					interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "Yes. Talk to me at any point during this tutorial", "if you change your mind.");
 					stage = 99;
 					break;
 				case 40:
-					interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "Very well. Have fun, adventurer.");
+					interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "Very well. Have fun, adventurer.");
 					stage = 99;
 					break;
 
@@ -177,15 +177,15 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 				case 502:
 					switch (buttonId) {
 						case 1:
-							player("Yes, please.");
+							interpreter.sendDialogues(npc, FacialExpression.HAPPY,"Yes, please.");
 							stage = 506;
 							break;
 						case 2:
-							player("What is an Ironman account?");
+							interpreter.sendDialogues(npc, FacialExpression.ASKING,"What is an Ironman account?");
 							stage = 530;
 							break;
 						case 3:
-							player("No, thanks.");
+							interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"No, thanks.");
 							stage = 534;
 							break;
 					}
@@ -218,30 +218,30 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 
 					//Split Dialogue depending on if the Player is talking to the Magic Instructor or Skippy.
 					if (npc.getId() == 946) {
-						npc("Congratulations, you have setup your Ironman account.", "Let's continue.");
+						interpreter.sendDialogues(npc, FacialExpression.HAPPY,"Congratulations, you have setup your Ironman account.", "Let's continue.");
 						stage = 1199;
 						break;
 					} else {
-						npc("Congratulations, you have setup your Ironman account.", "You will travel to the mainland in a moment.");
+						interpreter.sendDialogues(npc, FacialExpression.FRIENDLY,"Congratulations, you have setup your Ironman account.", "You will travel to the mainland in a moment.");
 						stage = 1204;
 						break;
 					}
 
 					//About Ironman mode
 				case 530:
-					npc("An Iron Man account is a style of playing where players", "are completely self-sufficient.");
+					interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"An Iron Man account is a style of playing where players", "are completely self-sufficient.");
 					stage++;
 					break;
 				case 531:
-					npc("A Standard Ironman does not receive items or", "assistance from other players. They cannot trade, stake,", "receive PK loot, scavenge dropped items, nor play", "certain minigames.");
+					interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"A Standard Ironman does not receive items or", "assistance from other players. They cannot trade, stake,", "receive PK loot, scavenge dropped items, nor play", "certain minigames.");
 					stage++;
 					break;
 				case 532:
-					npc("In addition to Standard Ironman restrictions,", "<col=8A0808>Hardcore</col> Ironmen only have one life. In the event of","a dangerous death, a player will be downgraded to a", "Standard Ironman, and their stats frozen on the hiscores.");
+					interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"In addition to Standard Ironman restrictions,", "<col=8A0808>Hardcore</col> Ironmen only have one life. In the event of","a dangerous death, a player will be downgraded to a", "Standard Ironman, and their stats frozen on the hiscores.");
 					stage++;
 					break;
 				case 533:
-					npc("For the ultimate challenge, players who choose the", "<col=ECEBEB>Ultimate</col> Ironman mode cannot use banks, nor", "retain any items on death in dangerous areas.");
+					interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"For the ultimate challenge, players who choose the", "<col=ECEBEB>Ultimate</col> Ironman mode cannot use banks, nor", "retain any items on death in dangerous areas.");
 					stage = 501;
 					break;
 
@@ -249,11 +249,11 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 					// From saying no thanks to being an ironman.
 					//Split Dialogue depending on if the Player is talking to the Magic Instructor or Skippy.
 					if (npc.getId() == 946) {
-						npc("Very well.", "Let's continue.");
+						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"Very well.", "Let's continue.");
 						stage = 1199;
 						break;
 					} else {
-						npc("Very well.", "You will travel to the mainland in a moment.");
+						interpreter.sendDialogues(npc, FacialExpression.NEUTRAL,"Very well.", "You will travel to the mainland in a moment.");
 						stage = 1204;
 						break;
 					}
@@ -266,16 +266,16 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 					interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "a question mark on the end. He also has a white beard","and carries a rucksack full of scrolls. There are also","many tutors willing to teach you about the many skills","you could learn.");
 					stage++;
 					break;
-				case 1201: //Needs to be the Lumbridge Guide Icon... Not sure of the ID or interface.
+				case 1201: //TODO: Needs to be the Lumbridge Guide Icon... Not sure of the ID or interface.
 					interpreter.sendItemMessage(RUNES[1], "When you get to Lumbridge, look for this icon on you","mini-map. The Lumbridge Guide or one of the other","tutors should be near there. The Lumbridge","Guide should be standing slightly to the north-east of");
 					stage++;
 					break;
-				case 1202: //Needs to be the Lumbridge Guide Icon... Not sure of the ID or interface.
+				case 1202: //TODO: Needs to be the Lumbridge Guide Icon... Not sure of the ID or interface.
 					interpreter.sendItemMessage(RUNES[1], "the castle's courtyard and the others you will find","scattered around Lumbridge.");
 					stage++;
 					break;
 				case 1203:
-					interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "If all else fails, visit the "+ GameWorld.getName()+ " website for a whole","chestload of information on quests, skills, and minigames","as well as a very good starter's guide.");
+					interpreter.sendDialogues(npc, FacialExpression.NEUTRAL, "If all else fails, visit the "+ GameWorld.getName()+ " website for a whole","chestload of information on quests, skills, and minigames","as well as a very good starter's guide.");
 					stage++;
 					break;
 
@@ -348,7 +348,7 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 			case 67:
 				switch (stage) {
 					case 0:
-						interpreter.sendDialogues(946, null, "Good day, newcomer. My name is Terrova. I'm here", "to tell you about Magic. Let's start by opening your", "spell list.");
+						interpreter.sendDialogues(946, FacialExpression.NEUTRAL, "Good day, newcomer. My name is Terrova. I'm here", "to tell you about Magic. Let's start by opening your", "spell list.");
 						stage = 1;
 						break;
 					case 1:

--- a/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
+++ b/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
@@ -198,13 +198,10 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 					switch (buttonId) {
 						case 1:
 						case 2:
-							npc("You have chosen the " + (buttonId == 1 ? "Standard" : "<col=8A0808>Hardcore</col>" + " Ironman mode."));
-							player.setAttribute("ironMode", IronmanMode.values()[buttonId]);
-							stage = 516;
-							break;
 						case 3:
-							npc("You have chosen the <col=ECEBEB>Ultimate</col> Ironman mode.");
-							player.setAttribute("ironMode", IronmanMode.ULTIMATE);
+							npc("You have chosen the " + (buttonId == 1 ? "Standard" : (buttonId == 2 ? "<col=8A0808>Hardcore</col>" : "<col=ECEBEB>Ultimate</col>")) + " Ironman mode.");
+							player.setAttribute("ironMode", IronmanMode.values()[buttonId]);
+							player.getSavedData().getActivityData().setHardcoreDeath(0);
 							stage = 516;
 							break;
 						case 4:

--- a/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
+++ b/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
@@ -201,7 +201,7 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 						case 3:
 							npc("You have chosen the " + (buttonId == 1 ? "Standard" : (buttonId == 2 ? "<col=8A0808>Hardcore</col>" : "<col=ECEBEB>Ultimate</col>")) + " Ironman mode.");
 							player.setAttribute("ironMode", IronmanMode.values()[buttonId]);
-							player.getSavedData().getActivityData().setHardcoreDeath(0); //might not be necessary?
+							player.getSavedData().getActivityData().setHardcoreDeath(false);
 							stage = 516;
 							break;
 						case 4:

--- a/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
+++ b/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
@@ -20,7 +20,7 @@ import org.crandor.plugin.InitializablePlugin;
  * Handles the tutorial completition dialogue (skippy, magic instructor)
  * @author Vexia
  * @author Splinter
- * 
+ *
  */
 @InitializablePlugin
 public class TutorialCompletionDialogue extends DialoguePlugin {
@@ -73,33 +73,33 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 		//Magic Instructor Dialogue
 		if (npc.getId() == 946) {
 			switch (TutorialSession.getExtension(player).getStage()) {
-			case 67:
-				interpreter.sendDialogues(player, null, "Hello.");
-				stage = 0;
-				return true;
-			case 69:
-				interpreter.sendDialogues(946, null, "Good. This is a list of your spells. Currently you can", "only cast one offensive spell called Wind Strike. Let's", "try it out on one of those chickens.");
-				stage = 0;
-				return true;
-			case 70:
-				if (!player.getInventory().contains(556, 1) && !player.getInventory().contains(558, 1)) {
-					if (player.getInventory().hasSpaceFor(RUNES[0]) && player.getInventory().hasSpaceFor(RUNES[1])) {
-						interpreter.sendDoubleItemMessage(RUNES[0], RUNES[1], "Terrova gives you five <col=08088A>air runes</col> and five <col=08088A>mind runes</col>!");
-						player.getInventory().add(RUNES);
-						stage = 3;
+				case 67:
+					interpreter.sendDialogues(player, null, "Hello.");
+					stage = 0;
+					return true;
+				case 69:
+					interpreter.sendDialogues(946, null, "Good. This is a list of your spells. Currently you can", "only cast one offensive spell called Wind Strike. Let's", "try it out on one of those chickens.");
+					stage = 0;
+					return true;
+				case 70:
+					if (!player.getInventory().contains(556, 1) && !player.getInventory().contains(558, 1)) {
+						if (player.getInventory().hasSpaceFor(RUNES[0]) && player.getInventory().hasSpaceFor(RUNES[1])) {
+							interpreter.sendDoubleItemMessage(RUNES[0], RUNES[1], "Terrova gives you five <col=08088A>air runes</col> and five <col=08088A>mind runes</col>!");
+							player.getInventory().add(RUNES);
+							stage = 3;
+						} else {
+							GroundItemManager.create(RUNES, player.getLocation(), player);
+							stage = 3;
+						}
 					} else {
-						GroundItemManager.create(RUNES, player.getLocation(), player);
-						stage = 3;
+						end();
+						TutorialStage.load(player, 70, false);
 					}
-				} else {
-					end();
-					TutorialStage.load(player, 70, false);
-				}
-				return true;
-			case 71:
-				interpreter.sendDialogues(946, null, "Well you're all finished here now. I'll give you a", "reasonable number of runes when you leave.");
-				stage = -2;
-				return true;
+					return true;
+				case 71:
+					interpreter.sendDialogues(946, null, "Well you're all finished here now. I'll give you a", "reasonable number of runes when you leave.");
+					stage = -2;
+					return true;
 			}
 		}
 
@@ -186,23 +186,28 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 							break;
 						case 3:
 							player("No, thanks.");
-							stage = 533;
+							stage = 534;
 							break;
 					}
 					break;
 				case 506:
-					interpreter.sendOptions("Select a Mode", "Standard", "<col=CC0000>Ultimate</col>", "Go back.");
+					interpreter.sendOptions("Select a Mode", "Standard", "<col=8A0808>Hardcore</col>", "<col=ECEBEB>Ultimate</col>", "Go back.");
 					stage++;
 					break;
 				case 507:
 					switch (buttonId) {
 						case 1:
 						case 2:
-							npc("You have chosen the " + (buttonId == 1 ? "Standard" : "<col=CC0000>Ultimate</col>") + " mode.");
+							npc("You have chosen the " + (buttonId == 1 ? "Standard" : "<col=8A0808>Hardcore</col>" + " Ironman mode."));
 							player.setAttribute("ironMode", IronmanMode.values()[buttonId]);
 							stage = 516;
 							break;
 						case 3:
+							npc("You have chosen the <col=ECEBEB>Ultimate</col> Ironman mode.");
+							player.setAttribute("ironMode", IronmanMode.ULTIMATE);
+							stage = 516;
+							break;
+						case 4:
 							player.removeAttribute("ironMode");
 							player.removeAttribute("ironPermanent");
 							options("Yes, please.", "What is an Ironman account?", "No, thanks.");
@@ -211,7 +216,7 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 					}
 					break;
 				case 516:
-					player.getIronmanManager().setMode(player.getAttribute("ironMode", IronmanMode.NONE));
+					player.getIronmanManager().setMode(player.getAttribute("ironMode"));
 					MSPacketRepository.sendInfoUpdate(player);
 
 					//Split Dialogue depending on if the Player is talking to the Magic Instructor or Skippy.
@@ -224,19 +229,26 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 						stage = 1204;
 						break;
 					}
+
+					//About Ironman mode
 				case 530:
-					npc("An Ironman account is a style of playing where players", "are completely self-sufficient.");
+					npc("An Iron Man account is a style of playing where players", "are completely self-sufficient.");
 					stage++;
 					break;
 				case 531:
-					npc("A standard Ironman does not receive items or", "assistance from other players. They cannot trade, stake,", "receieve PK loot, scavenge dropped items, nor player", "certain minigames.");
+					npc("A Standard Ironman does not receive items or", "assistance from other players. They cannot trade, stake,", "receive PK loot, scavenge dropped items, nor play", "certain minigames.");
 					stage++;
 					break;
 				case 532:
-					npc("In addition to the standard Ironman rules. An", "Ultimate Ironman cannot use banks, nor retain any", "items on death in dangerous areas.");
-					stage = 501;
+					npc("In addition to Standard Ironman restrictions,", "<col=8A0808>Hardcore</col> Ironmen only have one life. In the event of","a dangerous death, a player will be downgraded to a", "Standard Ironman, and their stats frozen on the hiscores.");
+					stage++;
 					break;
 				case 533:
+					npc("For the ultimate challenge, players who choose the", "<col=ECEBEB>Ultimate</col> Ironman mode cannot use banks, nor", "retain any items on death in dangerous areas.");
+					stage = 501;
+					break;
+
+				case 534:
 					// From saying no thanks to being an ironman.
 					//Split Dialogue depending on if the Player is talking to the Magic Instructor or Skippy.
 					if (npc.getId() == 946) {
@@ -248,136 +260,136 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 						stage = 1204;
 						break;
 					}
-			//Final Regards from the Magic Instructor
-			case 1199:
-				interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "When you get to the mainland you will find yourself in", "the town of Lumbridge. If you want some ideas on", "where to go next talk to my friend the Lumbridge", "Guide. You can't miss him; he's holding a big staff with");
-				stage++;
-				break;
-			case 1200:
-				interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "a question mark on the end. He also has a white beard","and carries a rucksack full of scrolls. There are also","many tutors willing to teach you about the many skills","you could learn.");
-				stage++;
-				break;
-			case 1201: //Needs to be the Lumbridge Guide Icon... Not sure of the ID or interface.
-				interpreter.sendItemMessage(RUNES[1], "When you get to Lumbridge, look for this icon on you","mini-map. The Lumbridge Guide or one of the other","tutors should be near there. The Lumbridge","Guide should be standing slightly to the north-east of");
-				stage++;
-				break;
-			case 1202: //Needs to be the Lumbridge Guide Icon... Not sure of the ID or interface.
-				interpreter.sendItemMessage(RUNES[1], "the castle's courtyard and the others you will find","scattered around Lumbridge.");
-				stage++;
-				break;
-			case 1203:
-				interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "If all else fails, visit the "+ GameWorld.getName()+ " website for a whole","chestload of information on quests, skills, and minigames","as well as a very good starter's guide.");
-				stage++;
-				break;
-
-			//Final words, if using Skippy it should go straight to this
-			//Could be removed to try and keep the 'nostalgic' feeling of Tutorial Island.
-			case 1204:
-				npc("Keep in mind: our server has more content than any other", "server ever released. There's hundreds of hours of", "exciting and flawless gameplay awaiting you, "+player.getUsername()+".", "Enjoy your time playing "+GameWorld.getName()+"!");
-				stage++;
-				break;
-
-			//End of Tutorial
-			case 1205:
-				stage = 7; //Next Stage force ends any conversations?
-
-				//Removing Tutorial Island properties on the account (?) and sending the Player to Lumbridge
-				player.removeAttribute("tut-island");
-				player.getConfigManager().set(1021, 0);
-				player.getProperties().setTeleportLocation(new Location(3233, 3230));
-				TutorialSession.getExtension(player).setStage(72);
-				player.getInterfaceManager().closeOverlay();
-
-				//Clears and Resets the Player's account and focuses the default interface to their Inventory
-				player.getInventory().clear();
-				player.getEquipment().clear();
-				player.getBank().clear();
-				player.getInterfaceManager().restoreTabs(); //This still hides the Attack (double swords) in the player menu until Player wields a weapon.
-				player.getInterfaceManager().setViewedTab(3);
-				player.getInventory().add(STARTER_PACK);
-				player.getBank().add(STARTER_BANK);
-
-				//This overwrites the stuck dialogue after teleporting to Lumbridge for some reason
-				//Dialogue from 2007 or thereabouts
-				//Original is five lines, but if the same is done here it will break. Need to find another way of showing all this information.
-				interpreter.sendDialogue("Welcome to Lumbridge! To get more help, simply click on the","Lumbridge Guide or one of the Tutors - these can be found by looking","for the question mark icon on your mini-map. If you find you are","lost at any time, look for a signpost or use the Lumbridge Home Port Spell.");
-
-				//Appending the welcome message and some other stuff
-				player.getPacketDispatch().sendMessage("Welcome to " + GameWorld.getName() + ".");
-
-				
-
-				player.unlock();
-				TutorialSession.getExtension(player).setStage(TutorialSession.MAX_STAGE + 1);
-				if (player.getIronmanManager().isIronman() && player.getSettings().isAcceptAid()) {
-					player.getSettings().toggleAcceptAid();
-				}
-				if (WorldCommunicator.isEnabled()) {
-					MSPacketRepository.sendInfoUpdate(player);
-				}
-				int slot = player.getAttribute("tut-island:hi_slot", -1);
-				if (slot < 0 || slot >= HintIconManager.MAXIMUM_SIZE) {
+					//Final Regards from the Magic Instructor
+				case 1199:
+					interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "When you get to the mainland you will find yourself in", "the town of Lumbridge. If you want some ideas on", "where to go next talk to my friend the Lumbridge", "Guide. You can't miss him; he's holding a big staff with");
+					stage++;
 					break;
-				}
+				case 1200:
+					interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "a question mark on the end. He also has a white beard","and carries a rucksack full of scrolls. There are also","many tutors willing to teach you about the many skills","you could learn.");
+					stage++;
+					break;
+				case 1201: //Needs to be the Lumbridge Guide Icon... Not sure of the ID or interface.
+					interpreter.sendItemMessage(RUNES[1], "When you get to Lumbridge, look for this icon on you","mini-map. The Lumbridge Guide or one of the other","tutors should be near there. The Lumbridge","Guide should be standing slightly to the north-east of");
+					stage++;
+					break;
+				case 1202: //Needs to be the Lumbridge Guide Icon... Not sure of the ID or interface.
+					interpreter.sendItemMessage(RUNES[1], "the castle's courtyard and the others you will find","scattered around Lumbridge.");
+					stage++;
+					break;
+				case 1203:
+					interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "If all else fails, visit the "+ GameWorld.getName()+ " website for a whole","chestload of information on quests, skills, and minigames","as well as a very good starter's guide.");
+					stage++;
+					break;
 
-				player.removeAttribute("tut-island:hi_slot");
-				HintIconManager.removeHintIcon(player, slot);
-				break;
-			case 7:
-				end();
-				break;
-			case 99:
-				end();
-				TutorialStage.load(player, TutorialSession.getExtension(player).getStage(), false);
-				break;
+				//Final words, if using Skippy it should go straight to this
+				//Could be removed to try and keep the 'nostalgic' feeling of Tutorial Island.
+				case 1204:
+					npc("Keep in mind: our server has more content than any other", "server ever released. There's hundreds of hours of", "exciting and flawless gameplay awaiting you, "+player.getUsername()+".", "Enjoy your time playing "+GameWorld.getName()+"!");
+					stage++;
+					break;
+
+				//End of Tutorial
+				case 1205:
+					stage = 7; //Next Stage force ends any conversations?
+
+					//Removing Tutorial Island properties on the account (?) and sending the Player to Lumbridge
+					player.removeAttribute("tut-island");
+					player.getConfigManager().set(1021, 0);
+					player.getProperties().setTeleportLocation(new Location(3233, 3230));
+					TutorialSession.getExtension(player).setStage(72);
+					player.getInterfaceManager().closeOverlay();
+
+					//Clears and Resets the Player's account and focuses the default interface to their Inventory
+					player.getInventory().clear();
+					player.getEquipment().clear();
+					player.getBank().clear();
+					player.getInterfaceManager().restoreTabs(); //This still hides the Attack (double swords) in the player menu until Player wields a weapon.
+					player.getInterfaceManager().setViewedTab(3);
+					player.getInventory().add(STARTER_PACK);
+					player.getBank().add(STARTER_BANK);
+
+					//This overwrites the stuck dialogue after teleporting to Lumbridge for some reason
+					//Dialogue from 2007 or thereabouts
+					//Original is five lines, but if the same is done here it will break. Need to find another way of showing all this information.
+					interpreter.sendDialogue("Welcome to Lumbridge! To get more help, simply click on the","Lumbridge Guide or one of the Tutors - these can be found by looking","for the question mark icon on your mini-map. If you find you are","lost at any time, look for a signpost or use the Lumbridge Home Port Spell.");
+
+					//Appending the welcome message and some other stuff
+					player.getPacketDispatch().sendMessage("Welcome to " + GameWorld.getName() + ".");
+
+
+
+					player.unlock();
+					TutorialSession.getExtension(player).setStage(TutorialSession.MAX_STAGE + 1);
+					if (player.getIronmanManager().isIronman() && player.getSettings().isAcceptAid()) {
+						player.getSettings().toggleAcceptAid();
+					}
+					if (WorldCommunicator.isEnabled()) {
+						MSPacketRepository.sendInfoUpdate(player);
+					}
+					int slot = player.getAttribute("tut-island:hi_slot", -1);
+					if (slot < 0 || slot >= HintIconManager.MAXIMUM_SIZE) {
+						break;
+					}
+
+					player.removeAttribute("tut-island:hi_slot");
+					HintIconManager.removeHintIcon(player, slot);
+					break;
+				case 7:
+					end();
+					break;
+				case 99:
+					end();
+					TutorialStage.load(player, TutorialSession.getExtension(player).getStage(), false);
+					break;
 			}
 			return true;
 		}
 
 		//Magic Instructor Dialogue during the Tutorial, Repeated from above?
 		switch (TutorialSession.getExtension(player).getStage()) {
-		case 67:
-			switch (stage) {
-			case 0:
-				interpreter.sendDialogues(946, null, "Good day, newcomer. My name is Terrova. I'm here", "to tell you about Magic. Let's start by opening your", "spell list.");
-				stage = 1;
-				break;
-			case 1:
-				end();
-				TutorialStage.load(player, 68, false);
-				break;
-			}
-			break;
-		case 69:
-			switch (stage) {
-			case 0:
-				if (!player.getInventory().contains(556, 1) && !player.getInventory().contains(558, 1)) {
-					if (player.getInventory().freeSlots() > 2) {
-						interpreter.sendDoubleItemMessage(RUNES[0], RUNES[1], "Terrova gives you five <col=08088A>air runes</col> and five <col=08088A>mind runes</col>!");
-						player.getInventory().add(RUNES[0], RUNES[1]);
-						stage = 3;
-					}
-				} else {
-					end();
-					TutorialStage.load(player, 70, false);
+			case 67:
+				switch (stage) {
+					case 0:
+						interpreter.sendDialogues(946, null, "Good day, newcomer. My name is Terrova. I'm here", "to tell you about Magic. Let's start by opening your", "spell list.");
+						stage = 1;
+						break;
+					case 1:
+						end();
+						TutorialStage.load(player, 68, false);
+						break;
 				}
 				break;
-			case 3:
-				end();
-				TutorialStage.load(player, 70, false);
+			case 69:
+				switch (stage) {
+					case 0:
+						if (!player.getInventory().contains(556, 1) && !player.getInventory().contains(558, 1)) {
+							if (player.getInventory().freeSlots() > 2) {
+								interpreter.sendDoubleItemMessage(RUNES[0], RUNES[1], "Terrova gives you five <col=08088A>air runes</col> and five <col=08088A>mind runes</col>!");
+								player.getInventory().add(RUNES[0], RUNES[1]);
+								stage = 3;
+							}
+						} else {
+							end();
+							TutorialStage.load(player, 70, false);
+						}
+						break;
+					case 3:
+						end();
+						TutorialStage.load(player, 70, false);
+						break;
+				}
 				break;
-			}
-			break;
-		case 70:
-			switch (stage) {
-			case 0:
+			case 70:
+				switch (stage) {
+					case 0:
+						break;
+					case 3:
+						end();
+						TutorialStage.load(player, 70, false);
+						break;
+				}
 				break;
-			case 3:
-				end();
-				TutorialStage.load(player, 70, false);
-				break;
-			}
-			break;
 		}
 		return true;
 	}

--- a/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
+++ b/Server/src/plugin/tutorial/TutorialCompletionDialogue.java
@@ -201,7 +201,7 @@ public class TutorialCompletionDialogue extends DialoguePlugin {
 						case 3:
 							npc("You have chosen the " + (buttonId == 1 ? "Standard" : (buttonId == 2 ? "<col=8A0808>Hardcore</col>" : "<col=ECEBEB>Ultimate</col>")) + " Ironman mode.");
 							player.setAttribute("ironMode", IronmanMode.values()[buttonId]);
-							player.getSavedData().getActivityData().setHardcoreDeath(0);
+							player.getSavedData().getActivityData().setHardcoreDeath(0); //might not be necessary?
 							stage = 516;
 							break;
 						case 4:


### PR DESCRIPTION
'Semi-TODO list' and 'Things to consider' under all this

### Iron Man Modes
___
Added Hardcore Iron Man mode in the IronManMode file. There is currently no Hardcore iron man logo within the cache/wherever icons are stored, so it is a red heart.

Commit Notes:
- Added Hardcore Iron Man Mode as an option
- Added //TODO to add HCIM logo

### Saved Activity Data
___
Originally, I had it so that there was a 'hidden' mode called HARDCORE_DEAD and players would only be given this status if they died as a hardcore ironman. I felt that would be too messy, so I switched it to an boolean, hardcoreDeath, that would be given to players; true if they die as a HCIM, false if they are still alive.

Commit Notes:
- Added a boolean to verify Hardcore Iron Man deaths
- Added two methods to set and get the value of the HCIM death
- Added HCIM death to the Player's saved data
- Added it to buffer (if this was not done, the player would be sent back to tutorial island)

### Players
___
Currently, a world announcement will be made if a player dies as a UIM. I've changed it so that it announces a HCIM death instead, with the addition of showing the player's total level when they died. The player class also handles the code that switches the player from a HCIM to a Standard IM, marks the player as a dead HCIM in the save data, and notifies the player that their Hardcore status has been revoked. 

Commit Notes:
- Changed the UIM check in finalizeDeath to HCIM
- Changed the check to use .equals() rather than checkRestriction(), preventing UIMs from being affected
- Added additional code to handle what happens to a player who has died in HCIM mode.

### HiScores
___
When a player dies as a HCIM, their marked as so - what happens to the HiScores? Whenever the HiScores SQL handler runs, it will now check to see if the save data has a hardcore death equal to one. If this condition is fulfilled, it will mark the IM mode as HARDCORE_DEAD. I've done this to differentiate the STANDARD iron men/women from the HCIM that have died; it might also assist with high-score formatting, to easily provide a condition to the webpage to strike-through any HCIM that have died.

Commit Notes:
- Added Check to see if the player has died previously on HCIM.
- Added separate SQL entry to execute specific SQL if the player passes that check.

### Minor Changes to Other Classes
___
Skills:
- Moved TotalSkillXP from HighscoreSQLHandler.java to Skills.java
- Indented a ton of methods

Tutorial Island Completion:
- Added some dialogue for HCIM mode
- Tweaked some other dialogue code
- Added a comment to denote a possibly unnecessary line of code
- Added some Facial Expressions

PlayerCommandPlugin:
- Changed all checkRestrictions() to getMode.equals() (avoids multiple counts)
- Adjusted the player count message to include IM, HCIM, and UIM.
___

### Removing/Changing Iron Man status
I made Hans allow you to remove or change your ironman status. However, Hans will not allow you to change or remove iron man modes for the following:

- A player is above 500 total level
- A player has more than 10 quest points
- For players who wish to be UIM, Hans will not change your status unless your bank is empty, to prevent item loss
- For players wanting to change to anything from a HCIM, Hans will not remove or change their status if they have died as a HCIM

Commit Notes:
- Added a ton of dialogue for Iron Man mode
- Added the ability to change ironman mode
- Added the ability to remove ironman mode
- Added some checks to see if the player was too high level or had too many quest points to change Iron man mode
- Added some checks to see if the player has died as an iron man
- Added check to see if player has an empty bank when changing to uim
- Changed some case numbers around
- Added a comment to denote a possibly unnecessary line of code
- Added some Facial Expressions


___
### Semi-TODO list (kinda tested, but not super extensively)
- Verify that the mode works
- Ensure that players who die as a HCIM (or login in general) do not get sent to tutorial island to repeat the tutorial
- Ensure that the death handling does not get triggered by safe events (Clan Wars comes to mind)
- Verify that Hans dialogue works (as the Hans that runs around the castle doesn't work for me)
- **Double check the highscore code to make sure no one can mess with the SQL**

### Other things to consider
- Temporarily turning off the de-iron/change iron for a day or two to allow people who joined before this update to change their status
- Adjusting the requirements (Total Skill Level/Quests Point) for changing Iron Man status
- Moving the remove/change ironman dialogue to another NPC to clean up Hans' dialogue or to promote moving around the map more (to an NPC in Varrock or Falador maybe?)
- Should Hans refuse to increase Iron Men/ Women from increasing their XP rates?